### PR TITLE
[C2-6008] Payment tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ The Yuno MCP server exposes the following tools for AI agents and automation:
 | `checkoutSession.create` | Create a checkout session |
 | `checkoutSession.retrievePaymentMethods` | Retrieve payment methods for checkout |
 | `payments.create` | Create a payment with various workflows |
-| `payments.read` | Retrieve payment information |
+| `payments.retrieve` | Retrieve payment information |
+| `payments.retrieveByMerchantOrderId` | Retrieve payment(s) by merchant_order_id |
+| `payments.refund` | Refund a payment (full or partial) by payment and transaction id |
+| `payments.cancelOrRefund` | Cancel or refund a payment by payment id (auto-detects action) |
+| `payments.cancelOrRefundWithTransaction` | Cancel or refund a payment by payment and transaction id (auto-detects action) |
+| `payments.cancel` | Cancel a pending payment by payment and transaction id |
+| `payments.authorize` | Authorize a payment (capture: false) |
+| `payments.captureAuthorization` | Capture a previously authorized payment |
 | `documentation.read` | Access Yuno API documentation and guides |
 
 ### Payment Workflows

--- a/src/client/YunoClient.ts
+++ b/src/client/YunoClient.ts
@@ -91,12 +91,9 @@ export class YunoClient {
   };
 
   payments = {
-    create: async (payment: YunoPayment, idempotencyKey?: string) => {
+    create: async (payment: YunoPayment, idempotencyKey: string) => {
       const headers: Record<string, string> = {};
-      if (idempotencyKey) {
-        headers['Idempotency-Key'] = idempotencyKey;
-      }
-
+      headers['x-idempotency-key'] = idempotencyKey;
       return this.request<YunoPayment>('/payments', {
         method: 'POST',
         headers,
@@ -107,6 +104,75 @@ export class YunoClient {
     retrieve: async (paymentId: string) => {
       return this.request<YunoPayment>(`/payments/${paymentId}`, {
         method: 'GET',
+      });
+    },
+
+    retrieveByMerchantOrderId: async (merchant_order_id: string) => {
+      return this.request<YunoPayment[]>(`/payments?merchant_order_id=${encodeURIComponent(merchant_order_id)}`, {
+        method: 'GET',
+      });
+    },
+
+    refund: async (paymentId: string, transactionId: string, body: any, idempotencyKey: string) => {
+      const headers: Record<string, string> = {};
+      headers['x-idempotency-key'] = idempotencyKey;
+      return this.request<any>(`/payments/${paymentId}/transactions/${transactionId}/refund`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+    },
+
+    cancelOrRefund: async (paymentId: string, body: any, idempotencyKey: string) => {
+      const headers: Record<string, string> = {};
+      headers['x-idempotency-key'] = idempotencyKey;
+      return this.request<any>(`/payments/${paymentId}/cancel-or-refund`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+    },
+
+    cancelOrRefundWithTransaction: async (paymentId: string, transactionId: string, body: any, idempotencyKey: string) => {
+      const headers: Record<string, string> = {};
+      headers['x-idempotency-key'] = idempotencyKey;
+      return this.request<any>(`/payments/${paymentId}/transactions/${transactionId}/cancel-or-refund`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+    },
+
+    cancel: async (paymentId: string, transactionId: string, body: any, idempotencyKey: string) => {
+      const headers: Record<string, string> = {};
+      headers['x-idempotency-key'] = idempotencyKey;
+      return this.request<any>(`/payments/${paymentId}/transactions/${transactionId}/cancel`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+    },
+
+    authorize: async (payment: YunoPayment, idempotencyKey: string) => {
+      const headers: Record<string, string> = {};
+      headers['x-idempotency-key'] = idempotencyKey;
+      if (payment && payment.payment_method && payment.payment_method.detail && payment.payment_method.detail.card) {
+        payment.payment_method.detail.card.capture = false;
+      }
+      return this.request<YunoPayment>('/payments', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payment),
+      });
+    },
+
+    captureAuthorization: async (paymentId: string, transactionId: string, body: any, idempotencyKey: string) => {
+      const headers: Record<string, string> = {};
+      headers['x-idempotency-key'] = idempotencyKey;
+      return this.request<any>(`/payments/${paymentId}/transactions/${transactionId}/capture`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
       });
     },
   };

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -74,24 +74,276 @@ export interface YunoCheckoutSession {
   installments?: YunoInstallments;
 }
 
+export interface YunoPaymentMethodStoredCredentials {
+  reason?: string;
+  usage?: string;
+  subscription_agreement_id?: string;
+  network_transaction_id?: string;
+}
+
+export interface YunoPaymentMethodCardData {
+  number: string;
+  expiration_month?: number;
+  expiration_year?: number;
+  security_code?: string;
+  holder_name: string;
+  type?: string;
+}
+
+export interface YunoPaymentMethodCard {
+  capture?: boolean;
+  installments?: number;
+  first_installment_deferral?: number;
+  soft_descriptor?: string;
+  card_data: YunoPaymentMethodCardData;
+  verify?: boolean;
+  stored_credentials?: YunoPaymentMethodStoredCredentials;
+}
+
+export interface YunoPaymentMethodDetail {
+  card?: YunoPaymentMethodCard;
+}
+
 export interface YunoPaymentMethod {
-  type: string;
   token?: string;
+  vaulted_token?: string;
+  type: string;
+  detail?: YunoPaymentMethodDetail;
+  vault_on_success?: boolean;
 }
 
 export interface YunoCheckout {
   session: string;
 }
 
+export interface YunoFraudScreening {
+  stand_alone?: boolean;
+}
+
+export interface YunoSplitMarketplaceAmount {
+  value: number;
+  currency: string;
+}
+
+export interface YunoSplitMarketplaceLiability {
+  processing_fee?: string;
+  chargebacks?: boolean;
+}
+
+export interface YunoSplitMarketplaceItem {
+  recipient_id?: string;
+  provider_recipient_id?: string;
+  type: string;
+  merchant_reference?: string;
+  amount: YunoSplitMarketplaceAmount;
+  liability?: YunoSplitMarketplaceLiability;
+}
+
+export type YunoSplitMarketplace = YunoSplitMarketplaceItem[];
+
+export interface YunoThreeDS {
+  email: string;
+  ip: string;
+}
+
+export interface YunoAdditionalData {
+  order?: YunoOrder;
+  airline?: YunoAirline;
+  seller_details?: YunoSellerDetails;
+}
+
 export interface YunoPayment {
+  account_id?: string;
   description: string;
+  additional_data?: YunoAdditionalData;
+  country: string;
   merchant_order_id: string;
-  country?: string;
+  merchant_reference?: string;
   amount: YunoAmount;
-  payment_method: YunoPaymentMethod;
+  customer_payer: {
+    id: string;
+    first_name: string;
+    last_name: string;
+    email: string;
+  };
   workflow: 'SDK_CHECKOUT' | 'DIRECT' | 'REDIRECT';
-  checkout?: YunoCheckout;
-  installments?: YunoInstallments;
+  payment_method: YunoPaymentMethod;
+  callback_url?: string;
+  fraud_screening?: YunoFraudScreening;
+  split_marketplace?: YunoSplitMarketplace;
+  metadata?: YunoMetadata[];
+}
+
+export interface YunoOrderTax {
+  type: string;
+  tax_base?: number;
+  value: number;
+  percentage?: number;
+}
+
+export interface YunoOrderItem {
+  id: string;
+  name: string;
+  quantity: number;
+  unit_amount: number;
+  category: string;
+  brand?: string;
+  sku_code?: string;
+  manufacture_part_number?: string;
+}
+
+export interface YunoOrderShipping {
+  type?: string;
+  description?: string;
+  carrier?: string;
+  deliver_at?: string;
+}
+
+export interface YunoOrderTicket {
+  id?: string;
+  name?: string;
+  description?: string;
+  type?: string;
+  amount?: {
+    currency: string;
+    value: number;
+  };
+  event?: {
+    id?: string;
+    name?: string;
+    description?: string;
+    type?: string;
+    date?: string;
+    address?: YunoAddress;
+  };
+}
+
+export interface YunoOrderAccountFundingParty {
+  national_entity: string;
+  first_name: string;
+  last_name: string;
+  legal_name?: string;
+  email: string;
+  country: string;
+  date_of_birth?: string;
+  document?: {
+    document_type: string;
+    document_number: string;
+  };
+  phone?: {
+    country_code: string;
+    number: string;
+  };
+  address?: YunoAddress;
+}
+
+export interface YunoOrderAccountFunding {
+  sender?: YunoOrderAccountFundingParty;
+  beneficiary?: YunoOrderAccountFundingParty;
+}
+
+export interface YunoOrderDiscount {
+  id: string;
+  name: string;
+  unit_amount?: number;
+}
+
+export interface YunoOrder {
+  shipping_amount?: number;
+  fee_amount?: number;
+  tip_amount?: string;
+  taxes?: YunoOrderTax[];
+  items?: YunoOrderItem[];
+  shipping?: YunoOrderShipping;
+  tickets?: YunoOrderTicket[];
+  account_funding?: YunoOrderAccountFunding;
+  discounts?: YunoOrderDiscount[];
+  sales_channel?: string;
+}
+
+export interface YunoAirlineLeg {
+  departure_airport: string;
+  departure_datetime: string;
+  departure_airport_country: string;
+  departure_airport_city: string;
+  departure_airport_timezone?: string;
+  arrival_airport: string;
+  arrival_airport_country: string;
+  arrival_airport_city: string;
+  arrival_airport_timezone?: string;
+  arrival_datetime?: string;
+  carrier_code: string;
+  flight_number: string;
+  fare_basis_code: string;
+  fare_class_code: string;
+  base_fare?: number;
+  base_fare_currency?: string;
+  stopover_code?: string;
+}
+
+export interface YunoAirlinePassenger {
+  first_name?: string;
+  last_name?: string;
+  middle_name?: string;
+  email?: string;
+  type?: string;
+  date_of_birth?: string;
+  nationality?: string;
+  document?: {
+    document_number: string;
+    document_type: string;
+  };
+  loyalty_number?: string;
+  loyalty_tier?: string;
+  phone?: {
+    country_code: string;
+    number: string;
+  };
+}
+
+export interface YunoAirlineTicket {
+  ticket_number?: string;
+  e_ticket?: boolean;
+  restricted?: boolean;
+  total_fare_amount?: number;
+  total_tax_amount?: number;
+  total_fee_amount?: number;
+  issue?: {
+    carrier_prefix_code?: string;
+    travel_agent_code?: string;
+    travel_agent_name?: string;
+    booking_system_code?: string;
+    booking_system_name?: string;
+    date?: string;
+    address?: string;
+    city?: string;
+    country?: string;
+  };
+}
+
+export interface YunoAirline {
+  pnr: string;
+  legs?: YunoAirlineLeg[];
+  passengers?: YunoAirlinePassenger[];
+  tickets?: YunoAirlineTicket[];
+}
+
+export interface YunoSellerDetails {
+  name?: string;
+  email?: string;
+  reference?: string;
+  website?: string;
+  industry?: string;
+  merchant_category_code?: string;
+  country: string;
+  document?: {
+    document_type: string;
+    document_number: string;
+  };
+  phone?: {
+    country_code?: string;
+    number?: string;
+  };
 }
 
 export interface YunoCheckoutPaymentMethod {


### PR DESCRIPTION
This pull request introduces several updates to the Yuno MCP server, focusing on expanding payment-related functionality and improving type definitions in the client library. Key changes include adding new payment APIs, modifying the `YunoClient` class to support these APIs, and significantly enhancing the `YunoPayment` and related type definitions.

### Payment API Enhancements:
* Updated the `README.md` to include new payment-related endpoints such as `payments.retrieveByMerchantOrderId`, `payments.refund`, `payments.cancelOrRefund`, and others, providing a wider range of payment management capabilities.
* Added new methods in the `YunoClient` class to implement the newly introduced payment APIs, including `retrieveByMerchantOrderId`, `refund`, `cancelOrRefund`, `cancel`, `authorize`, and `captureAuthorization`. These methods handle tasks such as refunds, cancellations, and payment authorization.

### Client Library Improvements:
* Modified the `create` method in the `YunoClient` class to enforce the `idempotencyKey` parameter and updated the header name to `x-idempotency-key` for consistency.

### Type Definitions Enhancements:
* Expanded the `YunoPayment` type to include new fields such as `additional_data`, `split_marketplace`, and `fraud_screening`, providing more detailed structures for payment-related data.
* Introduced new interfaces such as `YunoOrder`, `YunoAirline`, and `YunoSellerDetails`, offering comprehensive type definitions for advanced use cases like order details, airline ticketing, and seller information.