### PR TITLE
Fix/graceful zod validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuno/yuno-mcp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "exports": {
     ".": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import { YunoClient } from "./client";
 import { tools } from "./tools";
 import { Output } from "./types";
@@ -16,12 +17,36 @@ const yunoMCP = new McpServer(
 );
 
 for (const tool of tools) {
-  yunoMCP.tool(tool.method, tool.schema.shape, async (params: any) => {
+  // Pass the schema shape to the SDK for tool discovery/description,
+  // but wrap with a permissive schema so the SDK doesn't throw on validation.
+  // We validate manually inside the handler with safeParse to return
+  // user-friendly error messages instead of crashing with a 400.
+  const permissiveSchema = tool.schema.passthrough();
+
+  yunoMCP.tool(tool.method, permissiveSchema.shape, async (params: any) => {
     try {
       if (!yunoClient) {
         throw new Error("Yuno client not initialized");
       }
-      return await tool.handler({ yunoClient, type: "text" })(params);
+
+      // Validate params with the original strict schema using safeParse
+      const validation = tool.schema.safeParse(params);
+      if (!validation.success) {
+        const errors = validation.error.issues
+          .map((issue: z.ZodIssue) => `${issue.path.join(".")}: ${issue.message}`)
+          .join("; ");
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Validation error: ${errors}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return await tool.handler({ yunoClient, type: "text" })(validation.data);
     } catch (error) {
       if (error instanceof Error) {
         return { content: [{ type: "text" as const, text: error.message }] };


### PR DESCRIPTION
> Remember 
>- To add the JIRA number to the branch name (e.g. feature/JRA-NUMBER)
>- To add the JIRA number to the PR title
>- To add the JIRA number to the PR description
>- Delete this quote when you open the PR

***
## [JRA-NUMBER] [Pull request title]

### Description
[Provide a brief description of the changes and their purpose]

### What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Testing Coverage
- [ ] Other (Please describe)

### Related Tickets & Documents
[Cite any JIRA tickets or documents related to this PR]

## Database Checklist

### Migrations
- [ ] I have reviewed all included migrations with DBA Team.
- [ ] I have tested all migration scripts in a staging or development environment before production deployment.

### Complex Queries
- [ ] All complex SQL queries modifications / adding were checked against the optimization guide or DBA Team.

### Indexes & Performance
- [ ] I have all indexes in-place needed for my microservices to perform correctly.
- [ ] I've checked performance of my changes in a weekly Stress-Test session.

### Data Integrity and Constraints
- [ ] have ensured that all data integrity constraints such as foreign keys, unique constraints, and not null constraints are in place.

### Database Configuration Changes
- [ ] I have double-checked all changes to database pool configurations and made sure these are approved by the DBA.

### General Advice
- [ ] If reading this creates any doubts, pleaserefer to #dba_on_schedule for assistance.
- [ ] Do not hesitate to ask for help or a review of my database-related changes from the DBA Team.

## Security Checklist

### This PR introduces a new endpoint?
- [ ] Yes and I followed the bellow checklist:
  - [ ] I have added the necessary permission(s) to protect the endpoint.
  - [ ] I am not using any :userCode or :orgCode in the url or body. I am getting this user data from the user token
  - [ ] I have added the right account validation to the endpoint, preventing the user to access data from other accounts
- [ ] No

### This PR uses account codes to get or modify any information?
- [ ] Yes and I have added the right account validation to the endpoint, preventing the user to access data from other accounts
  - [ ] I tested that the affected endpoints accepts only accounts related to the user organization
  - [ ] I tested that the affected endpoints accepts only accounts where the user has permission to access
- [ ] No

### Data Governance Checklist (check all applicable)

- [ ] New tables and columns have comments in the migration file.
- [ ] The comments comply with the standard provided in the Confluence guide.
- [ ] Comments are written in English and do not contain special characters.
- [ ] For columns containing PII, the correct pii flag and category are included.
- [ ] Non-PII columns are correctly flagged as pii: false.

Note for more information check: https://yunopayments.atlassian.net/l/cp/TA1ZqM1n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tool parameter validation behavior by bypassing SDK-side strict validation and handling `zod` validation manually, which can affect how invalid inputs and extra fields are accepted and surfaced to clients.
> 
> **Overview**
> Tool registration in `src/index.ts` now uses a permissive `zod` schema (`passthrough`) to avoid SDK 400s, and performs manual `safeParse` validation inside each tool handler.
> 
> On validation failure, handlers return a structured `isError` response with aggregated, user-friendly issue messages instead of throwing. Package version is bumped to `0.1.6`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b27fedf1484375db043d8998b453b4cf1908aa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->