### PR TITLE
fix: update path-to-regexp to 8.4.0 (VULS-2342)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3935,9 +3935,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
## Summary
- Updates `path-to-regexp` from 8.3.0 to 8.4.0 (transitive via `@modelcontextprotocol/sdk -> express -> router`)
- Fixes Dependabot alerts #40 (High - DoS via sequential optional groups) and #41 (Medium - ReDoS via multiple wildcards)
- Resolves VULS-2342

## Test plan
- [x] `npm audit` shows 0 vulnerabilities
- [ ] Verify MCP server starts correctly
- [ ] Verify existing functionality is not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)