### PR TITLE
feat(CORECM-17032): make routing tools opt-in via includeRoutingTools…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuno/yuno-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "exports": {
     ".": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { YunoClient } from "./client";
-import { tools } from "./tools";
-import { Output } from "./types";
+import { tools, routingTools } from "./tools";
+import { Output, Tool } from "./types";
 
-function createYunoMCPServer(yunoClient: YunoClient) {
+type CreateOptions = {
+  includeRoutingTools?: boolean;
+};
+
+function createYunoMCPServer(yunoClient: YunoClient, options: CreateOptions = {}) {
   const server = new McpServer(
     {
       name: "yuno-mcp",
@@ -15,7 +19,11 @@ function createYunoMCPServer(yunoClient: YunoClient) {
     },
   );
 
-  for (const tool of tools) {
+  const enabledTools: readonly Tool[] = options.includeRoutingTools
+    ? [...tools, ...routingTools]
+    : tools;
+
+  for (const tool of enabledTools) {
     const permissiveSchema = tool.schema.passthrough();
 
     server.tool(tool.method, tool.description, permissiveSchema.shape, tool.annotations, async (params: any) => {
@@ -53,10 +61,12 @@ async function initializeYunoMCP({
   accountCode,
   publicApiKey,
   privateSecretKey,
+  includeRoutingTools,
 }: {
   accountCode: string;
   publicApiKey: string;
   privateSecretKey: string;
+  includeRoutingTools?: boolean;
 }) {
   try {
     const yunoClient = await YunoClient.initialize({
@@ -65,7 +75,7 @@ async function initializeYunoMCP({
       privateSecretKey,
     });
 
-    const yunoMCP = createYunoMCPServer(yunoClient);
+    const yunoMCP = createYunoMCPServer(yunoClient, { includeRoutingTools });
 
     return {
       yunoMCP,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -20,5 +20,6 @@ export const tools = [
   ...recipientTools,
   ...installmentPlanTools,
   ...documentationTools,
-    ...routingTools,
 ] as const satisfies Tool[];
+
+export { routingTools };


### PR DESCRIPTION
… flag

Routing tools (routingLogin, routingLogOut, routingCreate, routingUpdate, routingRetrieve, routingGetProviders, routingPost) require dashboard username/password auth and should not be exposed by default on transports that authenticate with API keys.

initializeYunoMCP now accepts an includeRoutingTools boolean (default false). When false, routing tools are not registered on the McpServer at all. Consumers that need routing (trusted local CLI) can opt in explicitly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default tool surface area by no longer registering routing (dashboard-auth) tools unless explicitly enabled, and updates the public initialization API to accept a new flag; consumers depending on routing tools may break if they don’t opt in.
> 
> **Overview**
> **Makes routing tools opt-in.** `initializeYunoMCP` and server creation now accept `includeRoutingTools`, and routing-related tools are only registered on the `McpServer` when that flag is true.
> 
> Updates tool exports so `tools` excludes routing by default (routing tools are exported separately as `routingTools`), and bumps the package version to `0.3.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41aaea4b61514ab8707ba0971a7c9b26fe66239f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->