### PR TITLE
Feat/corecm 17357 OpenAI apps submission requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@yuno/yuno-mcp",
   "version": "0.3.0",
+  "description": "Yuno MCP server: create and manage payments, subscriptions, customers, payment methods, checkouts, recipients, installment plans, payment links, and routing on the Yuno payments platform.",
   "type": "module",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuno/yuno-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Yuno MCP server: create and manage payments, subscriptions, customers, payment methods, checkouts, recipients, installment plans, payment links, and routing on the Yuno payments platform.",
   "type": "module",
   "exports": {

--- a/src/client/YunoClient.ts
+++ b/src/client/YunoClient.ts
@@ -192,7 +192,7 @@ export class YunoClient {
       });
     },
     retrieveEnrolled: async (customerId: string) => {
-      return this.request<YunoPaymentMethod[]>(`/customers/${customerId}/payment-methods`, {
+      return this.request<YunoPaymentMethod>(`/customers/${customerId}/payment-methods`, {
         method: "GET",
       });
     },
@@ -428,7 +428,7 @@ export class YunoClient {
     },
 
     retrieveAll: async (accountId: string) => {
-      return this.request<YunoInstallmentPlan[]>(`/installments-plans?account_id=${encodeURIComponent(accountId)}`, {
+      return this.request<YunoInstallmentPlan>(`/installments-plans?account_id=${encodeURIComponent(accountId)}`, {
         method: "GET",
       });
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ function createYunoMCPServer(yunoClient: YunoClient, options: CreateOptions = {}
     {
       name: "yuno-mcp",
       title: "Yuno",
-      version: "0.3.0",
+      version: "0.4.0",
       description:
         "Yuno MCP server: create and manage payments, subscriptions, customers, payment methods, checkouts, recipients, installment plans, payment links, and routing on the Yuno payments platform.",
       websiteUrl: "https://docs.y.uno/mcp",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { YunoClient } from "./client";
 import { tools, routingTools } from "./tools";
-import { Output, Tool } from "./types";
+import { Tool } from "./types";
 
 type CreateOptions = {
   includeRoutingTools?: boolean;
@@ -19,39 +19,66 @@ function createYunoMCPServer(yunoClient: YunoClient, options: CreateOptions = {}
     },
   );
 
-  const enabledTools: readonly Tool[] = options.includeRoutingTools
+  const enabledTools = options.includeRoutingTools
     ? [...tools, ...routingTools]
     : tools;
 
   for (const tool of enabledTools) {
     const permissiveSchema = tool.schema.passthrough();
+    const permissiveOutputSchema = tool.outputSchema?.passthrough();
 
-    server.tool(tool.method, tool.description, permissiveSchema.shape, tool.annotations, async (params: any) => {
-      try {
-        const validation = tool.schema.safeParse(params);
-        if (!validation.success) {
-          const errors = validation.error.issues.map((issue: z.ZodIssue) => `${issue.path.join(".")}: ${issue.message}`).join("; ");
+    server.registerTool(
+      tool.method,
+      {
+        title: tool.annotations.title,
+        description: tool.description,
+        inputSchema: permissiveSchema.shape,
+        outputSchema: permissiveOutputSchema?.shape,
+        annotations: tool.annotations,
+      },
+      async (params: any) => {
+        try {
+          const validation = tool.schema.safeParse(params);
+          if (!validation.success) {
+            const errors = validation.error.issues.map((issue: z.ZodIssue) => `${issue.path.join(".")}: ${issue.message}`).join("; ");
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `Validation error: ${errors}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+
+          const handlerResult = await tool.handler({ yunoClient, type: "object" })(validation.data as any);
+
+          const content: { type: "text"; text: string }[] = handlerResult.content.map((entry) => {
+            if (entry.type === "object") {
+              return { type: "text" as const, text: JSON.stringify(entry.object, null, 4) };
+            }
+            return { type: "text" as const, text: (entry as unknown as { type: "text"; text: string }).text };
+          });
+
+          if (!tool.outputSchema) {
+            return { content };
+          }
+
+          const primary = handlerResult.content.find((entry) => entry.type === "object");
+          const structuredContent = primary?.type === "object" ? (primary.object as Record<string, unknown>) : {};
+
+          return { content, structuredContent };
+        } catch (error) {
+          if (error instanceof Error) {
+            return { content: [{ type: "text" as const, text: error.message }] };
+          }
           return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Validation error: ${errors}`,
-              },
-            ],
-            isError: true,
+            content: [{ type: "text" as const, text: "An unknown error occurred" }],
           };
         }
-
-        return await tool.handler({ yunoClient, type: "text" })(validation.data as any);
-      } catch (error) {
-        if (error instanceof Error) {
-          return { content: [{ type: "text" as const, text: error.message }] };
-        }
-        return {
-          content: [{ type: "text" as const, text: "An unknown error occurred" }],
-        };
-      }
-    });
+      },
+    );
   }
 
   return server;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,11 @@ function createYunoMCPServer(yunoClient: YunoClient, options: CreateOptions = {}
   const server = new McpServer(
     {
       name: "yuno-mcp",
-      version: "1.4.0",
+      title: "Yuno",
+      version: "0.3.0",
+      description:
+        "Yuno MCP server: create and manage payments, subscriptions, customers, payment methods, checkouts, recipients, installment plans, payment links, and routing on the Yuno payments platform.",
+      websiteUrl: "https://docs.y.uno/mcp",
     },
     {
       capabilities: {},

--- a/src/schemas/checkouts.ts
+++ b/src/schemas/checkouts.ts
@@ -1,6 +1,81 @@
 import { z } from "zod";
 import { addressSchema, amountSchema, metadataSchema, browserInfoSchema, cardDataSchema, documentSchema, phoneSchema } from "./shared";
 
+const yunoCheckoutSessionOutputSchema = z
+  .object({
+    account_id: z.string().optional(),
+    amount: amountSchema,
+    customer_id: z.string().optional(),
+    merchant_order_id: z.string(),
+    payment_description: z.string(),
+    country: z.string().optional(),
+    callback_url: z.string().optional(),
+    metadata: metadataSchema,
+    installments: z
+      .object({
+        plan_id: z.string().optional(),
+        plan: z
+          .array(
+            z
+              .object({
+                installment: z.number().int(),
+                rate: z.number(),
+              })
+              .passthrough(),
+          )
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+const yunoCheckoutPaymentMethodsOutputSchema = z
+  .object({
+    payment_methods: z.array(
+      z
+        .object({
+          type: z.string(),
+          name: z.string(),
+          category: z.string().optional(),
+          provider: z.string().optional(),
+          status: z.string().optional(),
+          vaulted_token: z.string().optional(),
+        })
+        .passthrough(),
+    ),
+  })
+  .passthrough();
+
+const yunoOttOutputSchema = z
+  .object({
+    token: z.string(),
+    vaulted_token: z.string().nullable().optional(),
+    vault_on_success: z.boolean(),
+    type: z.string(),
+    card_data: cardDataSchema.optional(),
+    customer: z
+      .object({
+        first_name: z.string().nullable().optional(),
+        last_name: z.string().nullable().optional(),
+        email: z.string().nullable().optional(),
+        gender: z.string(),
+        phone: z.string().nullable().optional(),
+        date_of_birth: z.string().nullable().optional(),
+        billing_address: z.any().nullable().optional(),
+        shipping_address: z.any().nullable().optional(),
+        document: z.any().nullable().optional(),
+        browser_info: browserInfoSchema,
+        nationality: z.string().nullable().optional(),
+        device_fingerprint: z.any().nullable().optional(),
+      })
+      .passthrough(),
+    installment: z.any().nullable().optional(),
+    country: z.string(),
+    customer_session: z.any().nullable().optional(),
+  })
+  .passthrough();
+
 const checkoutSessionCreateSchema = z
   .object({
     account_id: z.string().min(36).max(64).describe("The unique identifier of the Yuno account").optional(),
@@ -83,4 +158,10 @@ const ottCreateSchema = z
   })
   .passthrough();
 
-export { checkoutSessionCreateSchema, ottCreateSchema };
+export {
+  checkoutSessionCreateSchema,
+  ottCreateSchema,
+  yunoCheckoutSessionOutputSchema,
+  yunoCheckoutPaymentMethodsOutputSchema,
+  yunoOttOutputSchema,
+};

--- a/src/schemas/customers.ts
+++ b/src/schemas/customers.ts
@@ -1,6 +1,23 @@
 import { z } from "zod";
 import { addressSchema, metadataSchema, phoneSchema, documentSchema } from "./shared";
 
+const yunoCustomerOutputSchema = z
+  .object({
+    merchant_customer_id: z.string().optional(),
+    first_name: z.string().optional(),
+    last_name: z.string().optional(),
+    gender: z.string().optional(),
+    date_of_birth: z.string().optional(),
+    email: z.string().optional(),
+    document: documentSchema,
+    phone: phoneSchema,
+    billing_address: addressSchema,
+    shipping_address: addressSchema,
+    metadata: metadataSchema,
+    merchant_customer_created_at: z.string().optional(),
+  })
+  .passthrough();
+
 const customerCreateSchema = z
   .object({
     merchant_customer_id: z.string().min(3).max(255),
@@ -40,4 +57,4 @@ const customerUpdateSchema = z
   })
   .passthrough();
 
-export { customerCreateSchema, customerUpdateSchema };
+export { customerCreateSchema, customerUpdateSchema, yunoCustomerOutputSchema };

--- a/src/schemas/documentation.ts
+++ b/src/schemas/documentation.ts
@@ -25,4 +25,22 @@ const documentationReadSchema = z.object({
   ),
 });
 
-export { documentationIndexSchema, documentationReadSchema, ALLOWED_DOCUMENTATION_HOST };
+const documentationIndexOutputSchema = z
+  .object({
+    content: z.string().optional().describe("Raw llms.txt documentation index text"),
+  })
+  .passthrough();
+
+const documentationReadOutputSchema = z
+  .object({
+    content: z.string().optional().describe("Raw documentation page text"),
+  })
+  .passthrough();
+
+export {
+  documentationIndexSchema,
+  documentationReadSchema,
+  documentationIndexOutputSchema,
+  documentationReadOutputSchema,
+  ALLOWED_DOCUMENTATION_HOST,
+};

--- a/src/schemas/installmentPlans.ts
+++ b/src/schemas/installmentPlans.ts
@@ -91,4 +91,57 @@ const installmentPlanUpdateSchema = z
   })
   .passthrough();
 
-export { installmentPlanCreateSchema, installmentPlanUpdateSchema };
+const yunoInstallmentPlanOutputSchema = z
+  .object({
+    name: z.string(),
+    account_id: z.array(z.string()).optional(),
+    merchant_reference: z.string(),
+    installments_plan: z
+      .array(
+        z
+          .object({
+            installment: z.number(),
+            rate: z.number(),
+            financial_costs: z
+              .array(
+                z
+                  .object({
+                    type: z.string(),
+                    rate: z.number(),
+                  })
+                  .passthrough(),
+              )
+              .optional(),
+            type: z.enum(["MERCHANT_INSTALLMENTS", "ISSUER_INSTALLMENTS"]).optional(),
+          })
+          .passthrough(),
+      )
+      .optional(),
+    country_code: z.string().optional(),
+    brand: z.array(z.string()).optional(),
+    issuer: z.string().optional(),
+    iin: z.array(z.string()).optional(),
+    first_installment_deferral: z.number().optional(),
+    amount: z
+      .object({
+        currency: z.string(),
+        min_value: z.number().optional(),
+        max_value: z.number().optional(),
+      })
+      .passthrough()
+      .optional(),
+    availability: z
+      .object({
+        start_at: z.string().optional(),
+        finish_at: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export {
+  installmentPlanCreateSchema,
+  installmentPlanUpdateSchema,
+  yunoInstallmentPlanOutputSchema,
+};

--- a/src/schemas/paymentLinks.ts
+++ b/src/schemas/paymentLinks.ts
@@ -1,6 +1,27 @@
 import { z } from "zod";
 import { addressSchema, amountSchema, documentSchema, metadataSchema, phoneSchema } from "./shared";
 
+const yunoPaymentLinkOutputSchema = z
+  .object({
+    account_id: z.string().optional(),
+    description: z.string().optional(),
+    country: z.string(),
+    merchant_order_id: z.string().optional(),
+    additional_data: z.any().optional(),
+    url: z.string().optional(),
+    status: z.string().optional(),
+    amount: z
+      .object({
+        currency: z.string(),
+        value: z.number(),
+      })
+      .passthrough(),
+    payment_method_types: z.array(z.string()),
+    metadata: metadataSchema,
+    cancelled_at: z.string().optional(),
+  })
+  .passthrough();
+
 const customerPayerSchema = z
   .object({
     id: z.string().min(36).max(64).optional().describe("The unique identifier of the customer in uuid v4 format"),
@@ -69,4 +90,4 @@ const paymentLinkCancelSchema = z
   .passthrough()
   .describe("Parameters for payment link cancellation");
 
-export { paymentLinkCreateSchema, paymentLinkCancelSchema };
+export { paymentLinkCreateSchema, paymentLinkCancelSchema, yunoPaymentLinkOutputSchema };

--- a/src/schemas/paymentMethods.ts
+++ b/src/schemas/paymentMethods.ts
@@ -33,4 +33,16 @@ const paymentMethodEnrollSchema = z
   })
   .passthrough();
 
-export { paymentMethodEnrollSchema };
+const yunoPaymentMethodOutputSchema = z
+  .object({
+    name: z.string().optional(),
+    description: z.string().optional(),
+    type: z.string().optional(),
+    country: z.string().optional(),
+    status: z.string().optional(),
+    sub_status: z.string().optional(),
+    vaulted_token: z.string().optional(),
+  })
+  .passthrough();
+
+export { paymentMethodEnrollSchema, yunoPaymentMethodOutputSchema };

--- a/src/schemas/payments.ts
+++ b/src/schemas/payments.ts
@@ -213,4 +213,115 @@ const paymentCaptureAuthorizationSchema = z
   })
   .passthrough();
 
-export { paymentCreateSchema, paymentRefundSchema, paymentCancelSchema, paymentCaptureAuthorizationSchema };
+const yunoPaymentOutputSchema = z
+  .object({
+    account_id: z.string().optional(),
+    description: z.string().optional(),
+    additional_data: z.any().optional(),
+    country: z.string().optional(),
+    merchant_order_id: z.string().optional(),
+    merchant_reference: z.string().optional(),
+    amount: amountSchema.optional(),
+    customer_payer: z
+      .object({
+        id: z.string().optional(),
+        first_name: z.string().optional(),
+        last_name: z.string().optional(),
+        email: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    workflow: z.string().optional(),
+    payment_method: z
+      .object({
+        token: z.string().optional(),
+        vaulted_token: z.string().optional(),
+        type: z.string().optional(),
+        detail: z
+          .object({
+            card: z
+              .object({
+                capture: z.boolean().optional(),
+                installments: z.number().optional(),
+                first_installment_deferral: z.number().optional(),
+                soft_descriptor: z.string().optional(),
+                card_data: z
+                  .object({
+                    number: z.string().optional(),
+                    expiration_month: z.number().optional(),
+                    expiration_year: z.number().optional(),
+                    security_code: z.string().optional(),
+                    holder_name: z.string().optional(),
+                    type: z.string().optional(),
+                  })
+                  .passthrough()
+                  .optional(),
+                verify: z.boolean().optional(),
+                stored_credentials: z
+                  .object({
+                    reason: z.string().optional(),
+                    usage: z.string().optional(),
+                    subscription_agreement_id: z.string().optional(),
+                    network_transaction_id: z.string().optional(),
+                  })
+                  .passthrough()
+                  .optional(),
+              })
+              .passthrough()
+              .optional(),
+          })
+          .passthrough()
+          .optional(),
+        vault_on_success: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
+    callback_url: z.string().optional(),
+    fraud_screening: z
+      .object({ stand_alone: z.boolean().optional() })
+      .passthrough()
+      .optional(),
+    split_marketplace: z
+      .array(
+        z
+          .object({
+            recipient_id: z.string().optional(),
+            provider_recipient_id: z.string().optional(),
+            type: z.string().optional(),
+            merchant_reference: z.string().optional(),
+            amount: z
+              .object({
+                value: z.number().optional(),
+                currency: z.string().optional(),
+              })
+              .passthrough()
+              .optional(),
+            liability: z
+              .object({
+                processing_fee: z.string().optional(),
+                chargebacks: z.boolean().optional(),
+              })
+              .passthrough()
+              .optional(),
+          })
+          .passthrough(),
+      )
+      .optional(),
+    metadata: metadataSchema,
+  })
+  .passthrough();
+
+const yunoPaymentListOutputSchema = z
+  .object({
+    items: z.array(yunoPaymentOutputSchema),
+  })
+  .passthrough();
+
+export {
+  paymentCreateSchema,
+  paymentRefundSchema,
+  paymentCancelSchema,
+  paymentCaptureAuthorizationSchema,
+  yunoPaymentOutputSchema,
+  yunoPaymentListOutputSchema,
+};

--- a/src/schemas/recipients.ts
+++ b/src/schemas/recipients.ts
@@ -146,4 +146,65 @@ const recipientUpdateSchema = z
   })
   .passthrough();
 
-export { recipientCreateSchema, recipientUpdateSchema };
+const yunoRecipientOutputSchema = z
+  .object({
+    id: z.string().optional(),
+    account_id: z.string().optional(),
+    merchant_recipient_id: z.string().optional(),
+    national_entity: z.string().optional(),
+    entity_type: z.string().optional(),
+    first_name: z.string().optional(),
+    last_name: z.string().optional(),
+    legal_name: z.string().optional(),
+    email: z.string().optional(),
+    date_of_birth: z.string().optional(),
+    country: z.string().optional(),
+    website: z.string().optional(),
+    industry: z.string().optional(),
+    merchant_category_code: z.string().optional(),
+    status: z.string().optional(),
+    document: documentSchema,
+    phone: phoneSchema,
+    address: addressSchema,
+    withdrawal_methods: z
+      .object({
+        bank: z
+          .object({
+            code: z.string().optional(),
+            branch: z.string().optional(),
+            account: z.string().optional(),
+            account_type: z.string().optional(),
+            branch_digit: z.string().optional(),
+            account_digit: z.string().optional(),
+            routing: z.string().optional(),
+            country: z.string().optional(),
+            currency: z.string().optional(),
+            payout_schedule: z.string().optional(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+    legal_representatives: z
+      .array(
+        z
+          .object({
+            merchant_reference: z.string().optional(),
+            first_name: z.string().optional(),
+            last_name: z.string().optional(),
+            email: z.string().optional(),
+            date_of_birth: z.string().optional(),
+            country: z.string().optional(),
+            nationality: z.string().optional(),
+            title: z.string().optional(),
+            publicly_exposed_person: z.boolean().optional(),
+            ultimate_beneficial_owner: z.boolean().optional(),
+          })
+          .passthrough(),
+      )
+      .optional(),
+  })
+  .passthrough();
+
+export { recipientCreateSchema, recipientUpdateSchema, yunoRecipientOutputSchema };

--- a/src/schemas/routing.ts
+++ b/src/schemas/routing.ts
@@ -160,12 +160,215 @@ const workflowRequestSchema = z.object({
 
 });
 
-export { 
-    routingLoginSchema, 
-    routingCreateSchema, 
+const yunoRoutingLoginOutputSchema = z
+    .object({
+        access_token: z.string(),
+        mfa_token: z.string().optional(),
+        next_step: z.string().optional(),
+        authenticator_type: z.string().optional(),
+        secret: z.string().optional(),
+        barcode_uri: z.string().optional(),
+    })
+    .passthrough();
+
+const yunoConditionDetailOutputSchema = z
+    .object({
+        name: z.string().optional(),
+        description: z.string().optional(),
+        criteria: z.string().optional(),
+        operators: z.array(z.string()).optional(),
+        payment_methods: z.array(z.string()).optional(),
+        value_source: z.string().optional(),
+        icon: z.string().optional(),
+    })
+    .passthrough();
+
+const yunoConditionOutputSchema = z
+    .object({
+        condition_set_id: z.number().optional(),
+        condition_type: z.string().optional(),
+        values: z.array(z.any()).optional(),
+        conditional: z.string().optional(),
+        complex_name: z.string().nullable().optional(),
+        complex_index: z.string().nullable().optional(),
+        additional_field_name: z.string().nullable().optional(),
+        detail: yunoConditionDetailOutputSchema.optional(),
+        visible: z.boolean().optional(),
+        metadata_key: z.string().nullable().optional(),
+        time_period_repeat_amount: z.number().nullable().optional(),
+        time_period_repetition_days: z.number().nullable().optional(),
+        time_period_repeat_frequency: z.string().nullable().optional(),
+        time_period_start_time: z.string().nullable().optional(),
+        time_period_end_time: z.string().nullable().optional(),
+    })
+    .passthrough();
+
+const yunoRouteNextIndexOutputSchema = z
+    .object({
+        index: z.number().optional(),
+        percentage: z.number().optional(),
+    })
+    .passthrough();
+
+const yunoRouteOutputOutputSchema = z
+    .object({
+        has_split: z.boolean().optional(),
+        output: z.string().optional(),
+        order: z.number().optional(),
+        type: z.string().optional(),
+        next_route_indexes: z.array(yunoRouteNextIndexOutputSchema).optional(),
+        next_route_index: z.number().nullable().optional(),
+        name: z.string().nullable().optional(),
+        id: z.string().nullable().optional(),
+        decline_types: z.array(z.any()).optional(),
+    })
+    .passthrough();
+
+const yunoRouteDataOutputSchema = z
+    .object({
+        action: z.string().nullable().optional(),
+        integration_code: z.string().optional(),
+        provider_id: z.string().optional(),
+        provider_type: z.enum(["PAYMENT", "PROCESSOR"]).optional(),
+        provider_icon: z.string().optional(),
+        provider_name: z.string().optional(),
+        time_out: z.number().optional(),
+        monitor_message: z.boolean().optional(),
+        network_token_on: z.boolean().optional(),
+        network_token_enable: z.boolean().optional(),
+        smart_routing: z.boolean().optional(),
+        three_d_secure_exemptions: z.array(z.any()).optional(),
+        percentage: z.string().optional(),
+    })
+    .passthrough();
+
+const yunoRouteOutputSchema = z
+    .object({
+        index: z.number().optional(),
+        outputs: z.array(yunoRouteOutputOutputSchema).optional(),
+        data: yunoRouteDataOutputSchema.optional(),
+        type: z.enum(["PROVIDER", "CONDITION"]).optional(),
+        updated_at: z.string().optional(),
+        repair: z.boolean().optional(),
+        paused: z.boolean().optional(),
+        alerted: z.boolean().optional(),
+    })
+    .passthrough();
+
+const yunoConditionSetStartOutputSchema = z
+    .object({
+        index: z.number().optional(),
+        percentage: z.number().optional(),
+    })
+    .passthrough();
+
+const yunoConditionSetOutputSchema = z
+    .object({
+        editable: z.boolean().optional(),
+        sort_number: z.number().optional(),
+        conditions: z.array(yunoConditionOutputSchema).optional(),
+        routes: z.array(yunoRouteOutputSchema).optional(),
+        start: z.array(yunoConditionSetStartOutputSchema).optional(),
+        updated_at: z.string().optional(),
+        category: z.string().optional(),
+        expired: z.boolean().optional(),
+        threshold_code: z.string().nullable().optional(),
+        monitor_active: z.boolean().nullable().optional(),
+        id: z.number().optional(),
+        name: z.string().nullable().optional(),
+        description: z.string().nullable().optional(),
+        smart_routing_mode: z.string().nullable().optional(),
+    })
+    .passthrough();
+
+const yunoWorkflowOutputSchema = z
+    .object({
+        id: z.number().optional(),
+        code: z.string().optional(),
+        name: z.string().optional(),
+        status: z.string().optional(),
+        account_code: z.string().optional(),
+        created_at: z.string().optional(),
+        updated_at: z.string().optional(),
+        payment_method_type: z.string().optional(),
+        is_active: z.boolean().optional(),
+    })
+    .passthrough();
+
+const yunoWorkflowVersionOutputSchema = z
+    .object({
+        id: z.number().optional(),
+        workflow_id: z.number().optional(),
+        code: z.string().optional(),
+        status: z.string().optional(),
+        number: z.number().optional(),
+        created_at: z.string().optional(),
+        updated_at: z.string().optional(),
+        published_at: z.string().nullable().optional(),
+        name: z.string().optional(),
+        publishable: z.boolean().optional(),
+        favorite: z.boolean().optional(),
+        repair: z.boolean().optional(),
+        updated_by: z.string().optional(),
+        payment_enabled: z.boolean().optional(),
+        fraud_enabled: z.boolean().optional(),
+        paused: z.boolean().optional(),
+        deleted_at: z.string().nullable().optional(),
+    })
+    .passthrough();
+
+const yunoRoutingWorkflowOutputSchema = z
+    .object({
+        workflow: yunoWorkflowOutputSchema.optional(),
+        version: yunoWorkflowVersionOutputSchema.optional(),
+        condition_sets: z.array(yunoConditionSetOutputSchema).optional(),
+    })
+    .passthrough();
+
+const yunoRoutingIntegrationOutputSchema = z
+    .object({
+        integration_code: z.string().optional(),
+        type: z.string().optional(),
+        provider_id: z.string().optional(),
+        icon: z.string().optional(),
+        name: z.string().optional(),
+        description: z.string().optional(),
+        active: z.boolean().optional(),
+        connection_name: z.string().optional(),
+        provider_icon: z.string().optional(),
+        category: z.string().optional(),
+        created_at: z.string().optional(),
+        updated_at: z.string().optional(),
+        provider_name: z.string().optional(),
+        connection_state: z.string().optional(),
+        flow_type: z.string().optional(),
+        costs: z.array(z.any()).optional(),
+    })
+    .passthrough();
+
+const yunoRoutingIntegrationsOutputSchema = z
+    .object({
+        integrations: z.array(yunoRoutingIntegrationOutputSchema).optional(),
+    })
+    .passthrough();
+
+const yunoRoutingLogoutOutputSchema = z
+    .object({
+        success: z.boolean().optional(),
+        message: z.string().optional(),
+    })
+    .passthrough();
+
+export {
+    routingLoginSchema,
+    routingCreateSchema,
     routingGetConnectionsSchema,
     workflowRequestSchema,
     workflowSchema,
     versionSchema,
-    conditionSetSchema
+    conditionSetSchema,
+    yunoRoutingLoginOutputSchema,
+    yunoRoutingWorkflowOutputSchema,
+    yunoRoutingIntegrationsOutputSchema,
+    yunoRoutingLogoutOutputSchema,
 };

--- a/src/schemas/subscriptions.ts
+++ b/src/schemas/subscriptions.ts
@@ -1,6 +1,77 @@
 import { z } from "zod";
 import { amountSchema, cardDataSchema, metadataSchema } from "./shared";
 
+const yunoSubscriptionOutputSchema = z
+  .object({
+    account_id: z.string().optional(),
+    name: z.string().optional(),
+    description: z.string().optional(),
+    merchant_reference: z.string().optional(),
+    amount: z
+      .object({
+        currency: z.string(),
+        value: z.number(),
+      })
+      .passthrough()
+      .optional(),
+    status: z.string().optional(),
+    additional_data: z.any().optional(),
+    frequency: z
+      .object({
+        type: z.enum(["DAY", "WEEK", "MONTH"]),
+        value: z.number().optional(),
+      })
+      .passthrough()
+      .optional(),
+    billing_cycles: z
+      .object({
+        total: z.number(),
+      })
+      .passthrough()
+      .optional(),
+    payment_method: z
+      .object({
+        type: z.enum(["CARD"]).optional(),
+        vaulted_token: z.string().optional(),
+        card: z
+          .object({
+            installments: z.number().optional(),
+            network_transaction_id: z.string().optional(),
+            verify: z.boolean().optional(),
+            card_data: z
+              .object({
+                number: z.string(),
+                expiration_month: z.number(),
+                expiration_year: z.number(),
+                security_code: z.union([z.string(), z.number()]),
+                holder_name: z.string(),
+              })
+              .passthrough()
+              .optional(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+    trial_period: z
+      .object({
+        billing_cycles: z.number().optional(),
+        amount: amountSchema.optional(),
+      })
+      .passthrough()
+      .optional(),
+    availability: z
+      .object({
+        start_at: z.string().optional(),
+        finish_at: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    metadata: metadataSchema,
+  })
+  .passthrough();
+
 const subscriptionCreateSchema = z
   .object({
     account_id: z.string().optional().describe("Account ID for the subscription"),
@@ -163,4 +234,4 @@ const subscriptionUpdateSchema = z
   })
   .passthrough();
 
-export { subscriptionCreateSchema, subscriptionUpdateSchema };
+export { subscriptionCreateSchema, subscriptionUpdateSchema, yunoSubscriptionOutputSchema };

--- a/src/tools/checkouts/index.ts
+++ b/src/tools/checkouts/index.ts
@@ -12,7 +12,7 @@ import type { YunoCheckoutPaymentMethodsResponse, YunoCheckoutSession, YunoOttCr
 export const checkoutSessionCreateTool = {
   method: "checkoutSessionCreate",
   description: "Create a new checkout session in Yuno.",
-  annotations: { title: "Create Checkout Session", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Create Checkout Session", destructiveHint: false, idempotentHint: false },
   schema: checkoutSessionCreateSchema,
   outputSchema: yunoCheckoutSessionOutputSchema,
   handler:
@@ -45,7 +45,7 @@ export const checkoutSessionCreateTool = {
 export const checkoutSessionRetrievePaymentMethodsTool = {
   method: "checkoutSessionRetrievePaymentMethods",
   description: "Retrieve payment methods for a checkout session in Yuno.",
-  annotations: { title: "Retrieve Checkout Payment Methods", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Checkout Payment Methods", readOnlyHint: true },
   schema: z.object({
     sessionId: z.string().describe("The unique identifier of the checkout session"),
   }),
@@ -76,7 +76,7 @@ export const checkoutSessionRetrievePaymentMethodsTool = {
 export const checkoutSessionCreateOttTool = {
   method: "checkoutSessionCreateOtt",
   description: "Generate a One Time Token (OTT) for a checkout session in Yuno.",
-  annotations: { title: "Create Checkout One-Time Token", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Create Checkout One-Time Token", destructiveHint: false, idempotentHint: false },
   schema: ottCreateSchema,
   outputSchema: yunoOttOutputSchema,
   handler:

--- a/src/tools/checkouts/index.ts
+++ b/src/tools/checkouts/index.ts
@@ -1,5 +1,11 @@
 import z from "zod";
-import { checkoutSessionCreateSchema, ottCreateSchema } from "../../schemas";
+import {
+  checkoutSessionCreateSchema,
+  ottCreateSchema,
+  yunoCheckoutPaymentMethodsOutputSchema,
+  yunoCheckoutSessionOutputSchema,
+  yunoOttOutputSchema,
+} from "../../schemas";
 import type { HandlerContext, Output, Tool } from "../../types";
 import type { YunoCheckoutPaymentMethodsResponse, YunoCheckoutSession, YunoOttCreateSchema, YunoOttRequest, YunoOttResponse } from "./types";
 
@@ -8,6 +14,7 @@ export const checkoutSessionCreateTool = {
   description: "Create a new checkout session in Yuno.",
   annotations: { title: "Create Checkout Session", destructiveHint: false, idempotentHint: false },
   schema: checkoutSessionCreateSchema,
+  outputSchema: yunoCheckoutSessionOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async (data: YunoCheckoutSession): Promise<Output<TType, YunoCheckoutSession>> => {
@@ -42,6 +49,7 @@ export const checkoutSessionRetrievePaymentMethodsTool = {
   schema: z.object({
     sessionId: z.string().describe("The unique identifier of the checkout session"),
   }),
+  outputSchema: yunoCheckoutPaymentMethodsOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ sessionId }: { sessionId: string }): Promise<Output<TType, YunoCheckoutPaymentMethodsResponse>> => {
@@ -70,6 +78,7 @@ export const checkoutSessionCreateOttTool = {
   description: "Generate a One Time Token (OTT) for a checkout session in Yuno.",
   annotations: { title: "Create Checkout One-Time Token", destructiveHint: false, idempotentHint: false },
   schema: ottCreateSchema,
+  outputSchema: yunoOttOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async (data: YunoOttCreateSchema): Promise<Output<TType, YunoOttResponse>> => {

--- a/src/tools/customers/index.ts
+++ b/src/tools/customers/index.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { customerCreateSchema, customerUpdateSchema } from "../../schemas";
+import { customerCreateSchema, customerUpdateSchema, yunoCustomerOutputSchema } from "../../schemas";
 import type { HandlerContext, Output, Tool } from "../../types";
 import type { CustomerUpdateSchema, YunoCustomer } from "./types";
 
@@ -8,6 +8,7 @@ export const customerCreateTool = {
   description: "Create a new customer in Yuno.",
   annotations: { title: "Create Customer", destructiveHint: false, idempotentHint: false },
   schema: customerCreateSchema,
+  outputSchema: yunoCustomerOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async (data: YunoCustomer): Promise<Output<TType, YunoCustomer>> => {
@@ -38,6 +39,7 @@ export const customerRetrieveTool = {
   schema: z.object({
     customerId: z.string().min(36).max(64).describe("The unique identifier of the customer to retrieve (MIN 36, MAX 64 characters)"),
   }),
+  outputSchema: yunoCustomerOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ customerId }: { customerId: string }): Promise<Output<TType, YunoCustomer>> => {
@@ -68,6 +70,7 @@ export const customerRetrieveByExternalIdTool = {
   schema: z.object({
     merchant_customer_id: z.string().describe("The external merchant_customer_id to retrieve the customer"),
   }),
+  outputSchema: yunoCustomerOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ merchant_customer_id }: { merchant_customer_id: string }): Promise<Output<TType, YunoCustomer>> => {
@@ -96,6 +99,7 @@ export const customerUpdateTool = {
   description: "Update a customer by ID.",
   annotations: { title: "Update Customer", destructiveHint: false, idempotentHint: true },
   schema: customerUpdateSchema,
+  outputSchema: yunoCustomerOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ customerId, ...updateFields }: CustomerUpdateSchema): Promise<Output<TType, YunoCustomer>> => {

--- a/src/tools/customers/index.ts
+++ b/src/tools/customers/index.ts
@@ -6,7 +6,7 @@ import type { CustomerUpdateSchema, YunoCustomer } from "./types";
 export const customerCreateTool = {
   method: "customerCreate",
   description: "Create a new customer in Yuno.",
-  annotations: { title: "Create Customer", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Create Customer", destructiveHint: false, idempotentHint: false },
   schema: customerCreateSchema,
   outputSchema: yunoCustomerOutputSchema,
   handler:
@@ -35,7 +35,7 @@ export const customerCreateTool = {
 export const customerRetrieveTool = {
   method: "customerRetrieve",
   description: "Retrieve a customer by ID.",
-  annotations: { title: "Retrieve Customer", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Customer", readOnlyHint: true },
   schema: z.object({
     customerId: z.string().min(36).max(64).describe("The unique identifier of the customer to retrieve (MIN 36, MAX 64 characters)"),
   }),
@@ -66,7 +66,7 @@ export const customerRetrieveTool = {
 export const customerRetrieveByExternalIdTool = {
   method: "customerRetrieveByExternalId",
   description: "Retrieve a customer by external merchant_customer_id.",
-  annotations: { title: "Retrieve Customer by External ID", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Customer by External ID", readOnlyHint: true },
   schema: z.object({
     merchant_customer_id: z.string().describe("The external merchant_customer_id to retrieve the customer"),
   }),
@@ -97,7 +97,7 @@ export const customerRetrieveByExternalIdTool = {
 export const customerUpdateTool = {
   method: "customerUpdate",
   description: "Update a customer by ID.",
-  annotations: { title: "Update Customer", destructiveHint: false, idempotentHint: true },
+  annotations: { openWorldHint: true, title: "Update Customer", destructiveHint: false, idempotentHint: true },
   schema: customerUpdateSchema,
   outputSchema: yunoCustomerOutputSchema,
   handler:

--- a/src/tools/documentation/index.ts
+++ b/src/tools/documentation/index.ts
@@ -25,7 +25,7 @@ const documentationIndexTool = {
   method: "documentationIndex",
   description:
     "Retrieve the Yuno documentation index (llms.txt) listing all available API references, SDK guides, and integration tutorials with their URLs.",
-  annotations: { title: "Yuno Documentation Index", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Yuno Documentation Index", readOnlyHint: true },
   schema: documentationIndexSchema,
   outputSchema: documentationIndexOutputSchema,
   handler:
@@ -63,7 +63,7 @@ const documentationReadTool = {
   method: "documentationRead",
   description:
     "Read a specific Yuno documentation page by URL. Use the documentation index tool first to discover available pages and their URLs.",
-  annotations: { title: "Read Yuno Documentation", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Read Yuno Documentation", readOnlyHint: true },
   schema: documentationReadSchema,
   outputSchema: documentationReadOutputSchema,
   handler:

--- a/src/tools/documentation/index.ts
+++ b/src/tools/documentation/index.ts
@@ -1,6 +1,14 @@
-import { ALLOWED_DOCUMENTATION_HOST, documentationIndexSchema, documentationReadSchema } from "../../schemas/documentation";
+import {
+  ALLOWED_DOCUMENTATION_HOST,
+  documentationIndexOutputSchema,
+  documentationIndexSchema,
+  documentationReadOutputSchema,
+  documentationReadSchema,
+} from "../../schemas/documentation";
 import type { HandlerContext, Output, Tool } from "../../types";
 import type { DocumentationReadSchema } from "./types";
+
+type DocumentationContent = { content: string };
 
 const LLMS_TXT_URL = `https://${ALLOWED_DOCUMENTATION_HOST}/llms.txt`;
 
@@ -19,25 +27,34 @@ const documentationIndexTool = {
     "Retrieve the Yuno documentation index (llms.txt) listing all available API references, SDK guides, and integration tutorials with their URLs.",
   annotations: { title: "Yuno Documentation Index", readOnlyHint: true },
   schema: documentationIndexSchema,
+  outputSchema: documentationIndexOutputSchema,
   handler:
     <TType extends "object" | "text">({ type }: HandlerContext<TType>) =>
-    async (): Promise<Output<TType>> => {
-      if (type === "object") {
-        throw new Error("Documentation index tool only supports text output");
-      }
-
+    async (): Promise<Output<TType, DocumentationContent>> => {
       try {
         const response = await fetch(LLMS_TXT_URL);
         if (!response.ok) {
           throw new Error(`Failed to fetch documentation index: HTTP ${response.status}`);
         }
         const text = await response.text();
-        return { content: [{ type: "text" as const, text }] } as Output<TType>;
-      } catch (error) {
-        if (error instanceof Error) {
-          return { content: [{ type: "text" as const, text: error.message }] } as Output<TType>;
+
+        if (type === "text") {
+          return { content: [{ type: "text" as const, text }] } as Output<TType, DocumentationContent>;
         }
-        return { content: [{ type: "text" as const, text: "Failed to fetch documentation index" }] } as Output<TType>;
+
+        return {
+          content: [{ type: "object" as const, object: { content: text } }],
+        } as Output<TType, DocumentationContent>;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to fetch documentation index";
+
+        if (type === "text") {
+          return { content: [{ type: "text" as const, text: message }] } as Output<TType, DocumentationContent>;
+        }
+
+        return {
+          content: [{ type: "object" as const, object: { content: message } }],
+        } as Output<TType, DocumentationContent>;
       }
     },
 } as const satisfies Tool;
@@ -48,22 +65,20 @@ const documentationReadTool = {
     "Read a specific Yuno documentation page by URL. Use the documentation index tool first to discover available pages and their URLs.",
   annotations: { title: "Read Yuno Documentation", readOnlyHint: true },
   schema: documentationReadSchema,
+  outputSchema: documentationReadOutputSchema,
   handler:
     <TType extends "object" | "text">({ type }: HandlerContext<TType>) =>
-    async ({ url }: DocumentationReadSchema): Promise<Output<TType>> => {
-      if (type === "object") {
-        throw new Error("Documentation read tool only supports text output");
-      }
-
+    async ({ url }: DocumentationReadSchema): Promise<Output<TType, DocumentationContent>> => {
       if (!isAllowedDocumentationUrl(url)) {
+        const refusal = `Refused: URL must be an https:// URL on ${ALLOWED_DOCUMENTATION_HOST}`;
+
+        if (type === "text") {
+          return { content: [{ type: "text" as const, text: refusal }] } as Output<TType, DocumentationContent>;
+        }
+
         return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Refused: URL must be an https:// URL on ${ALLOWED_DOCUMENTATION_HOST}`,
-            },
-          ],
-        } as Output<TType>;
+          content: [{ type: "object" as const, object: { content: refusal } }],
+        } as Output<TType, DocumentationContent>;
       }
 
       try {
@@ -72,12 +87,24 @@ const documentationReadTool = {
           throw new Error(`Failed to fetch documentation: HTTP ${response.status}`);
         }
         const text = await response.text();
-        return { content: [{ type: "text" as const, text }] } as Output<TType>;
-      } catch (error) {
-        if (error instanceof Error) {
-          return { content: [{ type: "text" as const, text: error.message }] } as Output<TType>;
+
+        if (type === "text") {
+          return { content: [{ type: "text" as const, text }] } as Output<TType, DocumentationContent>;
         }
-        return { content: [{ type: "text" as const, text: "Failed to fetch documentation" }] } as Output<TType>;
+
+        return {
+          content: [{ type: "object" as const, object: { content: text } }],
+        } as Output<TType, DocumentationContent>;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Failed to fetch documentation";
+
+        if (type === "text") {
+          return { content: [{ type: "text" as const, text: message }] } as Output<TType, DocumentationContent>;
+        }
+
+        return {
+          content: [{ type: "object" as const, object: { content: message } }],
+        } as Output<TType, DocumentationContent>;
       }
     },
 } as const satisfies Tool;

--- a/src/tools/installmentPlans/index.ts
+++ b/src/tools/installmentPlans/index.ts
@@ -1,5 +1,9 @@
 import z from "zod";
-import { installmentPlanCreateSchema, installmentPlanUpdateSchema } from "../../schemas";
+import {
+  installmentPlanCreateSchema,
+  installmentPlanUpdateSchema,
+  yunoInstallmentPlanOutputSchema,
+} from "../../schemas";
 import type { HandlerContext, Output, Tool } from "../../types";
 import type { InstallmentPlanCreateSchema, InstallmentPlanUpdateSchema, YunoInstallmentPlan } from "./types";
 
@@ -8,6 +12,7 @@ export const installmentPlanCreateTool = {
   description: "Create an installment plan in Yuno.",
   annotations: { title: "Create Installment Plan", destructiveHint: false, idempotentHint: false },
   schema: installmentPlanCreateSchema,
+  outputSchema: yunoInstallmentPlanOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async (data: InstallmentPlanCreateSchema): Promise<Output<TType, YunoInstallmentPlan>> => {
@@ -42,6 +47,7 @@ export const installmentPlanRetrieveTool = {
   schema: z.object({
     planId: z.string().describe("The unique identifier of the installment plan to retrieve"),
   }),
+  outputSchema: yunoInstallmentPlanOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ planId }: { planId: string }): Promise<Output<TType, YunoInstallmentPlan>> => {
@@ -72,9 +78,10 @@ export const installmentPlanRetrieveAllTool = {
   schema: z.object({
     accountId: z.string().describe("The account_id to retrieve all installment plans for"),
   }),
+  outputSchema: yunoInstallmentPlanOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
-    async ({ accountId }: { accountId: string }): Promise<Output<TType, YunoInstallmentPlan[]>> => {
+    async ({ accountId }: { accountId: string }): Promise<Output<TType, YunoInstallmentPlan>> => {
       const { body: plans, status, headers } = await yunoClient.installmentPlans.retrieveAll(accountId);
 
       if (type === "text") {
@@ -83,7 +90,7 @@ export const installmentPlanRetrieveAllTool = {
             { type: "text" as const, text: JSON.stringify(plans, null, 4) },
             { type: "text" as const, text: `Response Headers (HTTP ${status}):\n${JSON.stringify(headers, null, 4)}` },
           ],
-        } as Output<TType, YunoInstallmentPlan[]>;
+        } as Output<TType, YunoInstallmentPlan>;
       }
 
       return {
@@ -91,7 +98,7 @@ export const installmentPlanRetrieveAllTool = {
           { type: "object" as const, object: plans },
           { type: "text" as const, text: `Response Headers (HTTP ${status}):\n${JSON.stringify(headers, null, 4)}` },
         ],
-      } as Output<TType, YunoInstallmentPlan[]>;
+      } as Output<TType, YunoInstallmentPlan>;
     },
 } as const satisfies Tool;
 
@@ -100,6 +107,7 @@ export const installmentPlanUpdateTool = {
   description: "Update an installment plan in Yuno by its ID.",
   annotations: { title: "Update Installment Plan", destructiveHint: false, idempotentHint: true },
   schema: installmentPlanUpdateSchema,
+  outputSchema: yunoInstallmentPlanOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ planId, ...updateFields }: InstallmentPlanUpdateSchema): Promise<Output<TType, YunoInstallmentPlan>> => {
@@ -130,6 +138,7 @@ export const installmentPlanDeleteTool = {
   schema: z.object({
     planId: z.string().describe("The unique identifier of the installment plan to delete"),
   }),
+  outputSchema: yunoInstallmentPlanOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ planId }: { planId: string }): Promise<Output<TType, YunoInstallmentPlan>> => {

--- a/src/tools/installmentPlans/index.ts
+++ b/src/tools/installmentPlans/index.ts
@@ -10,7 +10,7 @@ import type { InstallmentPlanCreateSchema, InstallmentPlanUpdateSchema, YunoInst
 export const installmentPlanCreateTool = {
   method: "installmentPlanCreate",
   description: "Create an installment plan in Yuno.",
-  annotations: { title: "Create Installment Plan", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Create Installment Plan", destructiveHint: false, idempotentHint: false },
   schema: installmentPlanCreateSchema,
   outputSchema: yunoInstallmentPlanOutputSchema,
   handler:
@@ -43,7 +43,7 @@ export const installmentPlanCreateTool = {
 export const installmentPlanRetrieveTool = {
   method: "installmentPlanRetrieve",
   description: "Retrieve an installment plan in Yuno by its ID.",
-  annotations: { title: "Retrieve Installment Plan", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Installment Plan", readOnlyHint: true },
   schema: z.object({
     planId: z.string().describe("The unique identifier of the installment plan to retrieve"),
   }),
@@ -74,7 +74,7 @@ export const installmentPlanRetrieveTool = {
 export const installmentPlanRetrieveAllTool = {
   method: "installmentPlanRetrieveAll",
   description: "Retrieve all installment plans in Yuno for an account.",
-  annotations: { title: "Retrieve All Installment Plans", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve All Installment Plans", readOnlyHint: true },
   schema: z.object({
     accountId: z.string().describe("The account_id to retrieve all installment plans for"),
   }),
@@ -105,7 +105,7 @@ export const installmentPlanRetrieveAllTool = {
 export const installmentPlanUpdateTool = {
   method: "installmentPlanUpdate",
   description: "Update an installment plan in Yuno by its ID.",
-  annotations: { title: "Update Installment Plan", destructiveHint: false, idempotentHint: true },
+  annotations: { openWorldHint: true, title: "Update Installment Plan", destructiveHint: false, idempotentHint: true },
   schema: installmentPlanUpdateSchema,
   outputSchema: yunoInstallmentPlanOutputSchema,
   handler:
@@ -134,7 +134,7 @@ export const installmentPlanUpdateTool = {
 export const installmentPlanDeleteTool = {
   method: "installmentPlanDelete",
   description: "Delete an installment plan in Yuno by its ID.",
-  annotations: { title: "Delete Installment Plan", destructiveHint: true, idempotentHint: true },
+  annotations: { openWorldHint: true, title: "Delete Installment Plan", destructiveHint: true, idempotentHint: true },
   schema: z.object({
     planId: z.string().describe("The unique identifier of the installment plan to delete"),
   }),

--- a/src/tools/paymentLinks/index.ts
+++ b/src/tools/paymentLinks/index.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { paymentLinkCreateSchema, paymentLinkCancelSchema } from "../../schemas";
+import { paymentLinkCreateSchema, paymentLinkCancelSchema, yunoPaymentLinkOutputSchema } from "../../schemas";
 import type { HandlerContext, Output, Tool } from "../../types";
 import type { PaymentLinkCancelSchema, PaymentLinkCreateSchema, YunoPaymentLink } from "./types";
 
@@ -8,6 +8,7 @@ export const paymentLinkCreateTool = {
   description: "Create a payment link in Yuno.",
   annotations: { title: "Create Payment Link", destructiveHint: false, idempotentHint: false },
   schema: paymentLinkCreateSchema,
+  outputSchema: yunoPaymentLinkOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async (data: PaymentLinkCreateSchema): Promise<Output<TType, YunoPaymentLink>> => {
@@ -42,6 +43,7 @@ export const paymentLinkRetrieveTool = {
   schema: z.object({
     paymentLinkId: z.string().describe("The unique identifier of the payment link to retrieve"),
   }),
+  outputSchema: yunoPaymentLinkOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ paymentLinkId }: { paymentLinkId: string }): Promise<Output<TType, YunoPaymentLink>> => {
@@ -70,6 +72,7 @@ export const paymentLinkCancelTool = {
   description: "Cancel a payment link in Yuno by its ID.",
   annotations: { title: "Cancel Payment Link", destructiveHint: true, idempotentHint: true },
   schema: paymentLinkCancelSchema,
+  outputSchema: yunoPaymentLinkOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ paymentLinkId }: PaymentLinkCancelSchema): Promise<Output<TType, YunoPaymentLink>> => {

--- a/src/tools/paymentLinks/index.ts
+++ b/src/tools/paymentLinks/index.ts
@@ -6,7 +6,7 @@ import type { PaymentLinkCancelSchema, PaymentLinkCreateSchema, YunoPaymentLink 
 export const paymentLinkCreateTool = {
   method: "paymentLinkCreate",
   description: "Create a payment link in Yuno.",
-  annotations: { title: "Create Payment Link", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Create Payment Link", destructiveHint: false, idempotentHint: false },
   schema: paymentLinkCreateSchema,
   outputSchema: yunoPaymentLinkOutputSchema,
   handler:
@@ -39,7 +39,7 @@ export const paymentLinkCreateTool = {
 export const paymentLinkRetrieveTool = {
   method: "paymentLinkRetrieve",
   description: "Retrieve a payment link in Yuno by its ID.",
-  annotations: { title: "Retrieve Payment Link", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Payment Link", readOnlyHint: true },
   schema: z.object({
     paymentLinkId: z.string().describe("The unique identifier of the payment link to retrieve"),
   }),
@@ -70,7 +70,7 @@ export const paymentLinkRetrieveTool = {
 export const paymentLinkCancelTool = {
   method: "paymentLinkCancel",
   description: "Cancel a payment link in Yuno by its ID.",
-  annotations: { title: "Cancel Payment Link", destructiveHint: true, idempotentHint: true },
+  annotations: { openWorldHint: true, title: "Cancel Payment Link", destructiveHint: true, idempotentHint: true },
   schema: paymentLinkCancelSchema,
   outputSchema: yunoPaymentLinkOutputSchema,
   handler:

--- a/src/tools/paymentMethods/index.ts
+++ b/src/tools/paymentMethods/index.ts
@@ -1,5 +1,8 @@
 import z from "zod";
-import { paymentMethodEnrollSchema } from "../../schemas";
+import {
+  paymentMethodEnrollSchema,
+  yunoPaymentMethodOutputSchema,
+} from "../../schemas";
 import { randomUUID } from "node:crypto";
 import type { YunoClient } from "../../client";
 import type { HandlerContext, Output, Tool } from "../../types";
@@ -14,6 +17,7 @@ export const paymentMethodEnrollTool = {
     customerId: z.string().min(36).max(64).describe("The unique identifier of the customer (MIN 36, MAX 64)."),
     idempotencyKey: z.string().uuid().optional().describe("Unique key to prevent duplicate payment methods"),
   }),
+  outputSchema: yunoPaymentMethodOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({
@@ -58,6 +62,7 @@ export const paymentMethodRetrieveTool = {
     customer_id: z.string().min(36).max(64).describe("The unique identifier of the customer (MIN 36, MAX 64)."),
     payment_method_id: z.string().min(36).max(64).describe("The unique identifier of the payment method (MIN 36, MAX 64)."),
   }),
+  outputSchema: yunoPaymentMethodOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ customer_id, payment_method_id }: { customer_id: string; payment_method_id: string }): Promise<Output<TType, YunoPaymentMethod>> => {
@@ -88,9 +93,10 @@ export const paymentMethodRetrieveEnrolledTool = {
   schema: z.object({
     customer_id: z.string().min(36).max(64).describe("The unique identifier of the customer (MIN 36, MAX 64)."),
   }),
+  outputSchema: yunoPaymentMethodOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
-    async ({ customer_id }: { customer_id: string }): Promise<Output<TType, YunoPaymentMethod[]>> => {
+    async ({ customer_id }: { customer_id: string }): Promise<Output<TType, YunoPaymentMethod>> => {
       const { body, status, headers } = await yunoClient.paymentMethods.retrieveEnrolled(customer_id);
 
       if (type === "text") {
@@ -99,7 +105,7 @@ export const paymentMethodRetrieveEnrolledTool = {
             { type: "text" as const, text: JSON.stringify(body, null, 4) },
             { type: "text" as const, text: `Response Headers (HTTP ${status}):\n${JSON.stringify(headers, null, 4)}` },
           ],
-        } as Output<TType, YunoPaymentMethod[]>;
+        } as Output<TType, YunoPaymentMethod>;
       }
 
       return {
@@ -107,7 +113,7 @@ export const paymentMethodRetrieveEnrolledTool = {
           { type: "object" as const, object: body },
           { type: "text" as const, text: `Response Headers (HTTP ${status}):\n${JSON.stringify(headers, null, 4)}` },
         ],
-      } as Output<TType, YunoPaymentMethod[]>;
+      } as Output<TType, YunoPaymentMethod>;
     },
 } as const satisfies Tool;
 
@@ -119,6 +125,7 @@ export const paymentMethodUnenrollTool = {
     customer_id: z.string().min(36).max(64).describe("The unique identifier of the customer (MIN 36, MAX 64)."),
     payment_method_id: z.string().min(36).max(64).describe("The unique identifier of the payment method (MIN 36, MAX 64)."),
   }),
+  outputSchema: yunoPaymentMethodOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ customer_id, payment_method_id }: { customer_id: string; payment_method_id: string }): Promise<Output<TType, YunoPaymentMethod>> => {

--- a/src/tools/paymentMethods/index.ts
+++ b/src/tools/paymentMethods/index.ts
@@ -11,7 +11,7 @@ import type { PaymentMethodEnrollSchema, YunoPaymentMethod } from "./types";
 export const paymentMethodEnrollTool = {
   method: "paymentMethodEnroll",
   description: `Enroll or create payment method.`,
-  annotations: { title: "Enroll Payment Method", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Enroll Payment Method", destructiveHint: false, idempotentHint: false },
   schema: z.object({
     body: paymentMethodEnrollSchema,
     customerId: z.string().min(36).max(64).describe("The unique identifier of the customer (MIN 36, MAX 64)."),
@@ -57,7 +57,7 @@ export const paymentMethodEnrollTool = {
 export const paymentMethodRetrieveTool = {
   method: "paymentMethodRetrieve",
   description: `Retrieve an enrolled payment method by customer and payment method ID.`,
-  annotations: { title: "Retrieve Payment Method", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Payment Method", readOnlyHint: true },
   schema: z.object({
     customer_id: z.string().min(36).max(64).describe("The unique identifier of the customer (MIN 36, MAX 64)."),
     payment_method_id: z.string().min(36).max(64).describe("The unique identifier of the payment method (MIN 36, MAX 64)."),
@@ -89,7 +89,7 @@ export const paymentMethodRetrieveTool = {
 export const paymentMethodRetrieveEnrolledTool = {
   method: "paymentMethodRetrieveEnrolled",
   description: `Retrieve all enrolled payment methods for a customer.`,
-  annotations: { title: "Retrieve Enrolled Payment Methods", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Enrolled Payment Methods", readOnlyHint: true },
   schema: z.object({
     customer_id: z.string().min(36).max(64).describe("The unique identifier of the customer (MIN 36, MAX 64)."),
   }),
@@ -120,7 +120,7 @@ export const paymentMethodRetrieveEnrolledTool = {
 export const paymentMethodUnenrollTool = {
   method: "paymentMethodUnenroll",
   description: `Unenroll a saved payment method for the user.`,
-  annotations: { title: "Unenroll Payment Method", destructiveHint: true, idempotentHint: true },
+  annotations: { openWorldHint: true, title: "Unenroll Payment Method", destructiveHint: true, idempotentHint: true },
   schema: z.object({
     customer_id: z.string().min(36).max(64).describe("The unique identifier of the customer (MIN 36, MAX 64)."),
     payment_method_id: z.string().min(36).max(64).describe("The unique identifier of the payment method (MIN 36, MAX 64)."),

--- a/src/tools/payments/index.ts
+++ b/src/tools/payments/index.ts
@@ -21,7 +21,7 @@ import type {
 export const paymentCreateTool = {
   method: "paymentCreate",
   description: "Create a new payment in Yuno.",
-  annotations: { title: "Create Payment", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Create Payment", destructiveHint: false, idempotentHint: false },
   schema: paymentCreateSchema,
   outputSchema: yunoPaymentOutputSchema,
   handler:
@@ -67,7 +67,7 @@ export const paymentCreateTool = {
 export const paymentRetrieveTool = {
   method: "paymentRetrieve",
   description: "Retrieve a payment by ID in Yuno.",
-  annotations: { title: "Retrieve Payment", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Payment", readOnlyHint: true },
   schema: z.object({
     payment_id: z.string().describe("The unique identifier of the payment"),
   }),
@@ -110,7 +110,7 @@ export const paymentRetrieveTool = {
 export const paymentRetrieveByMerchantOrderIdTool = {
   method: "paymentRetrieveByMerchantOrderId",
   description: "Retrieve payments by merchant order ID in Yuno.",
-  annotations: { title: "Retrieve Payment by Merchant Order ID", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Payment by Merchant Order ID", readOnlyHint: true },
   schema: z.object({
     merchant_order_id: z.string().describe("The unique identifier of the order for the payment (merchant_order_id)"),
   }),
@@ -153,7 +153,7 @@ export const paymentRetrieveByMerchantOrderIdTool = {
 export const paymentRefundTool = {
   method: "paymentRefund",
   description: "Refund a payment in Yuno.",
-  annotations: { title: "Refund Payment", destructiveHint: true, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Refund Payment", destructiveHint: true, idempotentHint: false },
   schema: z.object({
     paymentId: z.string().min(36).max(64).describe("The unique identifier of the payment (MIN 36, MAX 64 characters)"),
     transactionId: z.string().min(36).max(64).describe("The unique identifier of the transaction (MIN 36, MAX 64 characters)"),
@@ -210,7 +210,7 @@ export const paymentRefundTool = {
 export const paymentCancelOrRefundTool = {
   method: "paymentCancelOrRefund",
   description: "Cancel or refund a payment in Yuno.",
-  annotations: { title: "Cancel or Refund Payment", destructiveHint: true, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Cancel or Refund Payment", destructiveHint: true, idempotentHint: false },
   schema: z.object({
     paymentId: z.string().min(36).max(64).describe("The unique identifier of the payment (MIN 36, MAX 64 characters)"),
     body: paymentRefundSchema,
@@ -264,7 +264,7 @@ export const paymentCancelOrRefundTool = {
 export const paymentCancelOrRefundWithTransactionTool = {
   method: "paymentCancelOrRefundWithTransaction",
   description: "Cancel or refund a payment with transaction in Yuno.",
-  annotations: { title: "Cancel or Refund Payment with Transaction", destructiveHint: true, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Cancel or Refund Payment with Transaction", destructiveHint: true, idempotentHint: false },
   schema: z.object({
     paymentId: z.string().min(36).max(64).describe("The unique identifier of the payment (MIN 36, MAX 64 characters)"),
     transactionId: z.string().min(36).max(64).describe("The unique identifier of the transaction (MIN 36, MAX 64 characters)"),
@@ -321,7 +321,7 @@ export const paymentCancelOrRefundWithTransactionTool = {
 export const paymentCancelTool = {
   method: "paymentCancel",
   description: "Cancel a payment in Yuno.",
-  annotations: { title: "Cancel Payment", destructiveHint: true, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Cancel Payment", destructiveHint: true, idempotentHint: false },
   schema: z.object({
     paymentId: z.string().min(36).max(64).describe("The unique identifier of the payment (MIN 36, MAX 64 characters)"),
     transactionId: z.string().min(36).max(64).describe("The unique identifier of the transaction (MIN 36, MAX 64 characters)"),
@@ -378,7 +378,7 @@ export const paymentCancelTool = {
 export const paymentAuthorizeTool = {
   method: "paymentAuthorize",
   description: "Authorize a payment in Yuno.",
-  annotations: { title: "Authorize Payment", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Authorize Payment", destructiveHint: false, idempotentHint: false },
   schema: paymentCreateSchema,
   outputSchema: yunoPaymentOutputSchema,
   handler:
@@ -430,7 +430,7 @@ export const paymentAuthorizeTool = {
 export const paymentCaptureAuthorizationTool = {
   method: "paymentCaptureAuthorization",
   description: "Capture an authorized payment in Yuno.",
-  annotations: { title: "Capture Payment Authorization", destructiveHint: true, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Capture Payment Authorization", destructiveHint: true, idempotentHint: false },
   schema: z.object({
     paymentId: z.string().min(36).max(64).describe("The unique identifier of the payment (MIN 36, MAX 64 characters)"),
     transactionId: z.string().min(36).max(64).describe("The unique identifier of the transaction (MIN 36, MAX 64 characters)"),

--- a/src/tools/payments/index.ts
+++ b/src/tools/payments/index.ts
@@ -1,5 +1,12 @@
 import z from "zod";
-import { paymentCancelSchema, paymentCaptureAuthorizationSchema, paymentCreateSchema, paymentRefundSchema } from "../../schemas";
+import {
+  paymentCancelSchema,
+  paymentCaptureAuthorizationSchema,
+  paymentCreateSchema,
+  paymentRefundSchema,
+  yunoPaymentOutputSchema,
+  yunoPaymentListOutputSchema,
+} from "../../schemas";
 import { randomUUID } from "node:crypto";
 import type { HandlerContext, Output, Tool } from "../../types";
 import type {
@@ -16,6 +23,7 @@ export const paymentCreateTool = {
   description: "Create a new payment in Yuno.",
   annotations: { title: "Create Payment", destructiveHint: false, idempotentHint: false },
   schema: paymentCreateSchema,
+  outputSchema: yunoPaymentOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ payment, idempotencyKey }: PaymentCreateSchema): Promise<Output<TType, YunoPayment>> => {
@@ -63,6 +71,7 @@ export const paymentRetrieveTool = {
   schema: z.object({
     payment_id: z.string().describe("The unique identifier of the payment"),
   }),
+  outputSchema: yunoPaymentOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ payment_id }: { payment_id: string }): Promise<Output<TType, YunoPayment>> => {
@@ -105,9 +114,10 @@ export const paymentRetrieveByMerchantOrderIdTool = {
   schema: z.object({
     merchant_order_id: z.string().describe("The unique identifier of the order for the payment (merchant_order_id)"),
   }),
+  outputSchema: yunoPaymentListOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
-    async ({ merchant_order_id }: { merchant_order_id: string }): Promise<Output<TType, YunoPayment[]>> => {
+    async ({ merchant_order_id }: { merchant_order_id: string }): Promise<Output<TType, { items: YunoPayment[] }>> => {
       const { body: payments, status, headers } = await yunoClient.payments.retrieveByMerchantOrderId(merchant_order_id);
 
       if (type === "text") {
@@ -122,21 +132,21 @@ export const paymentRetrieveByMerchantOrderIdTool = {
               text: `Response Headers (HTTP ${status}):\n${JSON.stringify(headers, null, 4)}`,
             },
           ],
-        } as Output<TType, YunoPayment[]>;
+        } as Output<TType, { items: YunoPayment[] }>;
       }
 
       return {
         content: [
           {
             type: "object" as const,
-            object: payments,
+            object: { items: payments },
           },
           {
             type: "text" as const,
             text: `Response Headers (HTTP ${status}):\n${JSON.stringify(headers, null, 4)}`,
           },
         ],
-      } as Output<TType, YunoPayment[]>;
+      } as Output<TType, { items: YunoPayment[] }>;
     },
 } as const satisfies Tool;
 
@@ -150,6 +160,7 @@ export const paymentRefundTool = {
     body: paymentRefundSchema,
     idempotencyKey: z.string().uuid().optional().describe("Unique key to prevent duplicate refunds"),
   }),
+  outputSchema: yunoPaymentOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({
@@ -205,6 +216,7 @@ export const paymentCancelOrRefundTool = {
     body: paymentRefundSchema,
     idempotencyKey: z.string().uuid().optional().describe("Unique key to prevent duplicate refunds"),
   }),
+  outputSchema: yunoPaymentOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({
@@ -259,6 +271,7 @@ export const paymentCancelOrRefundWithTransactionTool = {
     body: paymentRefundSchema,
     idempotencyKey: z.string().uuid().optional().describe("Unique key to prevent duplicate refunds"),
   }),
+  outputSchema: yunoPaymentOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({
@@ -315,6 +328,7 @@ export const paymentCancelTool = {
     body: paymentCancelSchema,
     idempotencyKey: z.string().uuid().optional().describe("Unique key to prevent duplicate cancellations"),
   }),
+  outputSchema: yunoPaymentOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({
@@ -366,6 +380,7 @@ export const paymentAuthorizeTool = {
   description: "Authorize a payment in Yuno.",
   annotations: { title: "Authorize Payment", destructiveHint: false, idempotentHint: false },
   schema: paymentCreateSchema,
+  outputSchema: yunoPaymentOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({
@@ -422,6 +437,7 @@ export const paymentCaptureAuthorizationTool = {
     body: paymentCaptureAuthorizationSchema,
     idempotencyKey: z.string().uuid().optional().describe("Unique key to prevent duplicate captures"),
   }),
+  outputSchema: yunoPaymentOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({

--- a/src/tools/recipients/index.ts
+++ b/src/tools/recipients/index.ts
@@ -7,7 +7,7 @@ import type { RecipientCreateSchema, RecipientUpdateSchema, YunoRecipient } from
 export const recipientCreateTool = {
   method: "recipientCreate",
   description: "Create a recipient in Yuno.",
-  annotations: { title: "Create Recipient", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Create Recipient", destructiveHint: false, idempotentHint: false },
   schema: recipientCreateSchema,
   outputSchema: yunoRecipientOutputSchema,
   handler:
@@ -40,7 +40,7 @@ export const recipientCreateTool = {
 export const recipientRetrieveTool = {
   method: "recipientRetrieve",
   description: "Retrieve a recipient in Yuno by its ID.",
-  annotations: { title: "Retrieve Recipient", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Recipient", readOnlyHint: true },
   schema: z.object({
     recipientId: z.string().describe("The unique identifier of the recipient to retrieve"),
   }),
@@ -71,7 +71,7 @@ export const recipientRetrieveTool = {
 export const recipientUpdateTool = {
   method: "recipientUpdate",
   description: "Update a recipient in Yuno by its ID.",
-  annotations: { title: "Update Recipient", destructiveHint: false, idempotentHint: true },
+  annotations: { openWorldHint: true, title: "Update Recipient", destructiveHint: false, idempotentHint: true },
   schema: recipientUpdateSchema,
   outputSchema: yunoRecipientOutputSchema,
   handler:
@@ -100,7 +100,7 @@ export const recipientUpdateTool = {
 export const recipientDeleteTool = {
   method: "recipientDelete",
   description: "Delete a recipient in Yuno by its ID.",
-  annotations: { title: "Delete Recipient", destructiveHint: true, idempotentHint: true },
+  annotations: { openWorldHint: true, title: "Delete Recipient", destructiveHint: true, idempotentHint: true },
   schema: z.object({
     recipientId: z.string().describe("The unique identifier of the recipient to delete"),
   }),

--- a/src/tools/recipients/index.ts
+++ b/src/tools/recipients/index.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { recipientCreateSchema, recipientUpdateSchema } from "../../schemas";
+import { recipientCreateSchema, recipientUpdateSchema, yunoRecipientOutputSchema } from "../../schemas";
 import type { HandlerContext, Tool } from "../../types";
 import type { Output } from "../../types";
 import type { RecipientCreateSchema, RecipientUpdateSchema, YunoRecipient } from "./types";
@@ -9,6 +9,7 @@ export const recipientCreateTool = {
   description: "Create a recipient in Yuno.",
   annotations: { title: "Create Recipient", destructiveHint: false, idempotentHint: false },
   schema: recipientCreateSchema,
+  outputSchema: yunoRecipientOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async (data: RecipientCreateSchema): Promise<Output<TType, YunoRecipient>> => {
@@ -43,6 +44,7 @@ export const recipientRetrieveTool = {
   schema: z.object({
     recipientId: z.string().describe("The unique identifier of the recipient to retrieve"),
   }),
+  outputSchema: yunoRecipientOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ recipientId }: { recipientId: string }): Promise<Output<TType, YunoRecipient>> => {
@@ -71,6 +73,7 @@ export const recipientUpdateTool = {
   description: "Update a recipient in Yuno by its ID.",
   annotations: { title: "Update Recipient", destructiveHint: false, idempotentHint: true },
   schema: recipientUpdateSchema,
+  outputSchema: yunoRecipientOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ recipientId, ...updateFields }: RecipientUpdateSchema): Promise<Output<TType, YunoRecipient>> => {
@@ -101,6 +104,7 @@ export const recipientDeleteTool = {
   schema: z.object({
     recipientId: z.string().describe("The unique identifier of the recipient to delete"),
   }),
+  outputSchema: yunoRecipientOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ recipientId }: { recipientId: string }): Promise<Output<TType, YunoRecipient>> => {

--- a/src/tools/routing/index.ts
+++ b/src/tools/routing/index.ts
@@ -1,4 +1,13 @@
-import { routingLoginSchema, routingCreateSchema, routingGetConnectionsSchema, workflowRequestSchema } from "../../schemas";
+import {
+    routingLoginSchema,
+    routingCreateSchema,
+    routingGetConnectionsSchema,
+    workflowRequestSchema,
+    yunoRoutingLoginOutputSchema,
+    yunoRoutingWorkflowOutputSchema,
+    yunoRoutingIntegrationsOutputSchema,
+    yunoRoutingLogoutOutputSchema,
+} from "../../schemas";
 import {
     YunoRoutingCreateSchema, YunoRoutingIntegrationResponse,
     YunoRoutingLogin,
@@ -9,9 +18,10 @@ import { z } from "zod";
 
 export const routingLoginTool = {
     method: "routingLogin",
-    description: "Authenticate to the Yuno dashboard. You must provide your username (email) and password. The remember_device option is automatically set to false for security.",
+    description: "Authenticate to the Yuno dashboard. You must provide your username (email) and your secret credential. The remember_device option is automatically set to false for security.",
     annotations: { title: "Login to Yuno Dashboard", destructiveHint: false, idempotentHint: true },
     schema: routingLoginSchema,
+    outputSchema: yunoRoutingLoginOutputSchema,
     handler:
         <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
             async (data: YunoRoutingLogin): Promise<Output<TType, YunoRoutingLoginResponse>> => {
@@ -40,6 +50,7 @@ export const routingCreateTool = {
     description: "Create a routing configuration. You must provide the name and payment method.",
     annotations: { title: "Create Routing Configuration", destructiveHint: false, idempotentHint: false },
     schema: routingCreateSchema,
+    outputSchema: yunoRoutingWorkflowOutputSchema,
     handler:
         <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
             async (data: YunoRoutingCreateSchema): Promise<Output<TType, YunoRoutingWorkflowResponse>> => {
@@ -68,6 +79,7 @@ export const routingGetProvidersTool = {
     description: "Retrieve all routing connections for a specific payment method. The account_code is automatically taken from the client configuration.",
     annotations: { title: "Retrieve Routing Providers", readOnlyHint: true },
     schema: routingGetConnectionsSchema,
+    outputSchema: yunoRoutingIntegrationsOutputSchema,
     handler:
         <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
             async (data: { paymentMethod: string }): Promise<Output<TType, YunoRoutingIntegrationResponse>> => {
@@ -97,6 +109,7 @@ export const routingRetrieveTool = {
     schema: z.object({
         versionCode: z.string().min(1).describe("The version code to retrieve"),
     }),
+    outputSchema: yunoRoutingWorkflowOutputSchema,
     handler:
         <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
             async (data: { versionCode: string }): Promise<Output<TType, YunoRoutingWorkflowResponse>> => {
@@ -124,6 +137,7 @@ export const routingUpdateTool = {
     description: "Configure a routing provider by setting up the provider connection in an existing workflow.",
     annotations: { title: "Update Routing Workflow", destructiveHint: false, idempotentHint: true },
     schema: workflowRequestSchema,
+    outputSchema: yunoRoutingWorkflowOutputSchema,
     handler:
         <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
             async (data: YunoRoutingUpdateWorkflow): Promise<Output<TType, YunoRoutingWorkflowResponse>> => {
@@ -153,6 +167,7 @@ export const routingPostTool = {
     schema: z.object({
         versionCode: z.string().min(1).describe("The version code to post"),
     }),
+    outputSchema: yunoRoutingWorkflowOutputSchema,
     handler:
         <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
             async (data: { versionCode: string }): Promise<Output<TType, YunoRoutingWorkflowResponse>> => {
@@ -180,11 +195,12 @@ export const routingLogOutTool = {
     description: "Log out from the Yuno dashboard. This will invalidate the current session.",
     annotations: { title: "Logout from Yuno Dashboard", destructiveHint: true, idempotentHint: true },
     schema: z.object({}),
+    outputSchema: yunoRoutingLogoutOutputSchema,
     handler:
         <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
             async (): Promise<Output<TType, YunoRoutingLogoutResponse>> => {
                 await yunoClient.routing.logout();
-                
+
                 // Create a success response since logout returns void
                 const result: YunoRoutingLogoutResponse = {
                     success: true,

--- a/src/tools/routing/index.ts
+++ b/src/tools/routing/index.ts
@@ -19,7 +19,7 @@ import { z } from "zod";
 export const routingLoginTool = {
     method: "routingLogin",
     description: "Authenticate to the Yuno dashboard. You must provide your username (email) and your secret credential. The remember_device option is automatically set to false for security.",
-    annotations: { title: "Login to Yuno Dashboard", destructiveHint: false, idempotentHint: true },
+    annotations: { openWorldHint: true, title: "Login to Yuno Dashboard", destructiveHint: false, idempotentHint: true },
     schema: routingLoginSchema,
     outputSchema: yunoRoutingLoginOutputSchema,
     handler:
@@ -48,7 +48,7 @@ export const routingLoginTool = {
 export const routingCreateTool = {
     method: "routingCreate",
     description: "Create a routing configuration. You must provide the name and payment method.",
-    annotations: { title: "Create Routing Configuration", destructiveHint: false, idempotentHint: false },
+    annotations: { openWorldHint: true, title: "Create Routing Configuration", destructiveHint: false, idempotentHint: false },
     schema: routingCreateSchema,
     outputSchema: yunoRoutingWorkflowOutputSchema,
     handler:
@@ -77,7 +77,7 @@ export const routingCreateTool = {
 export const routingGetProvidersTool = {
     method: "routingGetProviders",
     description: "Retrieve all routing connections for a specific payment method. The account_code is automatically taken from the client configuration.",
-    annotations: { title: "Retrieve Routing Providers", readOnlyHint: true },
+    annotations: { openWorldHint: true, title: "Retrieve Routing Providers", readOnlyHint: true },
     schema: routingGetConnectionsSchema,
     outputSchema: yunoRoutingIntegrationsOutputSchema,
     handler:
@@ -105,7 +105,7 @@ export const routingGetProvidersTool = {
 export const routingRetrieveTool = {
     method: "routingRetrieve",
     description: "Retrieve a routing workflow configuration by version code.",
-    annotations: { title: "Retrieve Routing Workflow", readOnlyHint: true },
+    annotations: { openWorldHint: true, title: "Retrieve Routing Workflow", readOnlyHint: true },
     schema: z.object({
         versionCode: z.string().min(1).describe("The version code to retrieve"),
     }),
@@ -135,7 +135,7 @@ export const routingRetrieveTool = {
 export const routingUpdateTool = {
     method: "routingUpdate",
     description: "Configure a routing provider by setting up the provider connection in an existing workflow.",
-    annotations: { title: "Update Routing Workflow", destructiveHint: false, idempotentHint: true },
+    annotations: { openWorldHint: true, title: "Update Routing Workflow", destructiveHint: false, idempotentHint: true },
     schema: workflowRequestSchema,
     outputSchema: yunoRoutingWorkflowOutputSchema,
     handler:
@@ -163,7 +163,7 @@ export const routingUpdateTool = {
 export const routingPostTool = {
     method: "routingPost",
     description: "Publish a routing workflow configuration to make it active in the Yuno API.",
-    annotations: { title: "Publish Routing Workflow", destructiveHint: true, idempotentHint: true },
+    annotations: { openWorldHint: true, title: "Publish Routing Workflow", destructiveHint: true, idempotentHint: true },
     schema: z.object({
         versionCode: z.string().min(1).describe("The version code to post"),
     }),
@@ -193,7 +193,7 @@ export const routingPostTool = {
 export const routingLogOutTool = {
     method: "routingLogOut",
     description: "Log out from the Yuno dashboard. This will invalidate the current session.",
-    annotations: { title: "Logout from Yuno Dashboard", destructiveHint: true, idempotentHint: true },
+    annotations: { openWorldHint: true, title: "Logout from Yuno Dashboard", destructiveHint: true, idempotentHint: true },
     schema: z.object({}),
     outputSchema: yunoRoutingLogoutOutputSchema,
     handler:

--- a/src/tools/subscriptions/index.ts
+++ b/src/tools/subscriptions/index.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { subscriptionCreateSchema, subscriptionUpdateSchema } from "../../schemas";
+import { subscriptionCreateSchema, subscriptionUpdateSchema, yunoSubscriptionOutputSchema } from "../../schemas";
 import { YunoClient } from "../../client";
 import type { HandlerContext, Output, Tool } from "../../types";
 import type { SubscriptionCreateSchema, SubscriptionUpdateSchema, YunoSubscription } from "./types";
@@ -9,6 +9,7 @@ export const subscriptionCreateTool = {
   description: "Create a subscription in Yuno.",
   annotations: { title: "Create Subscription", destructiveHint: false, idempotentHint: false },
   schema: subscriptionCreateSchema,
+  outputSchema: yunoSubscriptionOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async (data: SubscriptionCreateSchema): Promise<Output<TType, YunoSubscription>> => {
@@ -43,6 +44,7 @@ export const subscriptionRetrieveTool = {
   schema: z.object({
     subscriptionId: z.string().describe("The unique identifier of the subscription to retrieve"),
   }),
+  outputSchema: yunoSubscriptionOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ subscriptionId }: { subscriptionId: string }): Promise<Output<TType, YunoSubscription>> => {
@@ -73,6 +75,7 @@ export const subscriptionPauseTool = {
   schema: z.object({
     subscriptionId: z.string().describe("The unique identifier of the subscription to pause"),
   }),
+  outputSchema: yunoSubscriptionOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ subscriptionId }: { subscriptionId: string }): Promise<Output<TType, YunoSubscription>> => {
@@ -103,6 +106,7 @@ export const subscriptionResumeTool = {
   schema: z.object({
     subscriptionId: z.string().describe("The unique identifier of the subscription to resume"),
   }),
+  outputSchema: yunoSubscriptionOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ subscriptionId }: { subscriptionId: string }): Promise<Output<TType, YunoSubscription>> => {
@@ -131,6 +135,7 @@ export const subscriptionUpdateTool = {
   description: "Update a subscription in Yuno by its ID.",
   annotations: { title: "Update Subscription", destructiveHint: false, idempotentHint: true },
   schema: subscriptionUpdateSchema,
+  outputSchema: yunoSubscriptionOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ subscriptionId, ...updateFields }: SubscriptionUpdateSchema): Promise<Output<TType, YunoSubscription>> => {
@@ -161,6 +166,7 @@ export const subscriptionCancelTool = {
   schema: z.object({
     subscriptionId: z.string().describe("The unique identifier of the subscription to cancel"),
   }),
+  outputSchema: yunoSubscriptionOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ subscriptionId }: { subscriptionId: string }): Promise<Output<TType, YunoSubscription>> => {

--- a/src/tools/subscriptions/index.ts
+++ b/src/tools/subscriptions/index.ts
@@ -7,7 +7,7 @@ import type { SubscriptionCreateSchema, SubscriptionUpdateSchema, YunoSubscripti
 export const subscriptionCreateTool = {
   method: "subscriptionCreate",
   description: "Create a subscription in Yuno.",
-  annotations: { title: "Create Subscription", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, title: "Create Subscription", destructiveHint: false, idempotentHint: false },
   schema: subscriptionCreateSchema,
   outputSchema: yunoSubscriptionOutputSchema,
   handler:
@@ -40,7 +40,7 @@ export const subscriptionCreateTool = {
 export const subscriptionRetrieveTool = {
   method: "subscriptionRetrieve",
   description: "Retrieve a subscription in Yuno by its ID.",
-  annotations: { title: "Retrieve Subscription", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Subscription", readOnlyHint: true },
   schema: z.object({
     subscriptionId: z.string().describe("The unique identifier of the subscription to retrieve"),
   }),
@@ -71,7 +71,7 @@ export const subscriptionRetrieveTool = {
 export const subscriptionPauseTool = {
   method: "subscriptionPause",
   description: "Pause a subscription in Yuno by its ID.",
-  annotations: { title: "Pause Subscription", destructiveHint: true, idempotentHint: true },
+  annotations: { openWorldHint: true, title: "Pause Subscription", destructiveHint: true, idempotentHint: true },
   schema: z.object({
     subscriptionId: z.string().describe("The unique identifier of the subscription to pause"),
   }),
@@ -102,7 +102,7 @@ export const subscriptionPauseTool = {
 export const subscriptionResumeTool = {
   method: "subscriptionResume",
   description: "Resume a subscription in Yuno by its ID.",
-  annotations: { title: "Resume Subscription", destructiveHint: false, idempotentHint: true },
+  annotations: { openWorldHint: true, title: "Resume Subscription", destructiveHint: false, idempotentHint: true },
   schema: z.object({
     subscriptionId: z.string().describe("The unique identifier of the subscription to resume"),
   }),
@@ -133,7 +133,7 @@ export const subscriptionResumeTool = {
 export const subscriptionUpdateTool = {
   method: "subscriptionUpdate",
   description: "Update a subscription in Yuno by its ID.",
-  annotations: { title: "Update Subscription", destructiveHint: false, idempotentHint: true },
+  annotations: { openWorldHint: true, title: "Update Subscription", destructiveHint: false, idempotentHint: true },
   schema: subscriptionUpdateSchema,
   outputSchema: yunoSubscriptionOutputSchema,
   handler:
@@ -162,7 +162,7 @@ export const subscriptionUpdateTool = {
 export const subscriptionCancelTool = {
   method: "subscriptionCancel",
   description: "Cancel a subscription in Yuno by its ID.",
-  annotations: { title: "Cancel Subscription", destructiveHint: true, idempotentHint: true },
+  annotations: { openWorldHint: true, title: "Cancel Subscription", destructiveHint: true, idempotentHint: true },
   schema: z.object({
     subscriptionId: z.string().describe("The unique identifier of the subscription to cancel"),
   }),

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -70,6 +70,7 @@ type Tool = {
   description: string;
   annotations: ToolAnnotations;
   schema: z.ZodObject<any>;
+  outputSchema?: z.ZodObject<any>;
   handler: <TType extends "object" | "text">(context: HandlerContext<TType>) => (input: any) => Promise<Output<TType>>;
 };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because tool registration/output handling is refactored to use `registerTool` with optional structured outputs, and several client/tool return types change from arrays to single objects which could break consumers if the upstream API still returns lists.
> 
> **Overview**
> Bumps the package to `0.4.0` and updates MCP server metadata (adds `title`, `description`, `websiteUrl`) while switching tool wiring to `server.registerTool` and supporting optional `outputSchema` + `structuredContent` in responses.
> 
> Adds Zod *output* schemas for most tools (payments, customers, checkouts, subscriptions, payment links, recipients, installment plans, routing, documentation) and annotates tools with `openWorldHint`; documentation tools now support object output (wrapping content in `{ content }`) instead of being text-only.
> 
> Adjusts some client/tool typing for list-style endpoints (e.g., `paymentMethodRetrieveEnrolled`, `installmentPlanRetrieveAll`) and wraps `paymentRetrieveByMerchantOrderId` object output as `{ items: [...] }` to match the new list output schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862328977bf3494d091cf2b48cdd50724b3f834d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->