### PR TITLE
Fix/corecm 17357 output schema passthrough

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yuno/yuno-mcp",
-  "version": "0.1.7",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yuno/yuno-mcp",
-      "version": "0.1.7",
+      "version": "0.4.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",
         "zod": "^4.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuno/yuno-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Yuno MCP server: create and manage payments, subscriptions, customers, payment methods, checkouts, recipients, installment plans, payment links, and routing on the Yuno payments platform.",
   "type": "module",
   "exports": {

--- a/src/client/YunoClient.ts
+++ b/src/client/YunoClient.ts
@@ -192,7 +192,7 @@ export class YunoClient {
       });
     },
     retrieveEnrolled: async (customerId: string) => {
-      return this.request<YunoPaymentMethod>(`/customers/${customerId}/payment-methods`, {
+      return this.request<{ payment_methods?: YunoPaymentMethod[] | null }>(`/customers/${customerId}/payment-methods`, {
         method: "GET",
       });
     },
@@ -428,7 +428,7 @@ export class YunoClient {
     },
 
     retrieveAll: async (accountId: string) => {
-      return this.request<YunoInstallmentPlan>(`/installments-plans?account_id=${encodeURIComponent(accountId)}`, {
+      return this.request<YunoInstallmentPlan[]>(`/installments-plans?account_id=${encodeURIComponent(accountId)}`, {
         method: "GET",
       });
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ function createYunoMCPServer(yunoClient: YunoClient, options: CreateOptions = {}
     {
       name: "yuno-mcp",
       title: "Yuno",
-      version: "0.4.0",
+      version: "0.4.1",
       description:
         "Yuno MCP server: create and manage payments, subscriptions, customers, payment methods, checkouts, recipients, installment plans, payment links, and routing on the Yuno payments platform.",
       websiteUrl: "https://docs.y.uno/mcp",
@@ -37,7 +37,7 @@ function createYunoMCPServer(yunoClient: YunoClient, options: CreateOptions = {}
         title: tool.annotations.title,
         description: tool.description,
         inputSchema: permissiveSchema.shape,
-        outputSchema: permissiveOutputSchema?.shape,
+        outputSchema: permissiveOutputSchema,
         annotations: tool.annotations,
       },
       async (params: any) => {
@@ -69,17 +69,27 @@ function createYunoMCPServer(yunoClient: YunoClient, options: CreateOptions = {}
             return { content };
           }
 
+          const mixedContent = handlerResult.content as Array<
+            { type: "text"; text: string } | { type: "object"; object: unknown }
+          >;
+          const headersText = mixedContent.find(
+            (entry): entry is { type: "text"; text: string } =>
+              entry.type === "text" && /^Response Headers \(HTTP \d+\)/.test(entry.text),
+          );
+          const statusMatch = headersText?.text.match(/^Response Headers \(HTTP (\d+)\)/);
+          const upstreamStatus = statusMatch ? parseInt(statusMatch[1], 10) : 200;
+
+          if (upstreamStatus >= 400) {
+            return { content, isError: true };
+          }
+
           const primary = handlerResult.content.find((entry) => entry.type === "object");
           const structuredContent = primary?.type === "object" ? (primary.object as Record<string, unknown>) : {};
 
           return { content, structuredContent };
         } catch (error) {
-          if (error instanceof Error) {
-            return { content: [{ type: "text" as const, text: error.message }] };
-          }
-          return {
-            content: [{ type: "text" as const, text: "An unknown error occurred" }],
-          };
+          const text = error instanceof Error ? error.message : "An unknown error occurred";
+          return { content: [{ type: "text" as const, text }], isError: true };
         }
       },
     );

--- a/src/schemas/checkouts.ts
+++ b/src/schemas/checkouts.ts
@@ -3,17 +3,17 @@ import { addressSchema, amountSchema, metadataSchema, browserInfoSchema, cardDat
 
 const yunoCheckoutSessionOutputSchema = z
   .object({
-    account_id: z.string().optional(),
+    account_id: z.string().nullish(),
     amount: amountSchema,
-    customer_id: z.string().optional(),
+    customer_id: z.string().nullish(),
     merchant_order_id: z.string(),
     payment_description: z.string(),
-    country: z.string().optional(),
-    callback_url: z.string().optional(),
+    country: z.string().nullish(),
+    callback_url: z.string().nullish(),
     metadata: metadataSchema,
     installments: z
       .object({
-        plan_id: z.string().optional(),
+        plan_id: z.string().nullish(),
         plan: z
           .array(
             z
@@ -23,10 +23,10 @@ const yunoCheckoutSessionOutputSchema = z
               })
               .passthrough(),
           )
-          .optional(),
+          .nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
   })
   .passthrough();
 
@@ -37,10 +37,10 @@ const yunoCheckoutPaymentMethodsOutputSchema = z
         .object({
           type: z.string(),
           name: z.string(),
-          category: z.string().optional(),
-          provider: z.string().optional(),
-          status: z.string().optional(),
-          vaulted_token: z.string().optional(),
+          category: z.string().nullish(),
+          provider: z.string().nullish(),
+          status: z.string().nullish(),
+          vaulted_token: z.string().nullish(),
         })
         .passthrough(),
     ),
@@ -50,54 +50,54 @@ const yunoCheckoutPaymentMethodsOutputSchema = z
 const yunoOttOutputSchema = z
   .object({
     token: z.string(),
-    vaulted_token: z.string().nullable().optional(),
+    vaulted_token: z.string().nullish(),
     vault_on_success: z.boolean(),
     type: z.string(),
-    card_data: cardDataSchema.optional(),
+    card_data: cardDataSchema.nullish(),
     customer: z
       .object({
-        first_name: z.string().nullable().optional(),
-        last_name: z.string().nullable().optional(),
-        email: z.string().nullable().optional(),
+        first_name: z.string().nullish(),
+        last_name: z.string().nullish(),
+        email: z.string().nullish(),
         gender: z.string(),
-        phone: z.string().nullable().optional(),
-        date_of_birth: z.string().nullable().optional(),
-        billing_address: z.any().nullable().optional(),
-        shipping_address: z.any().nullable().optional(),
-        document: z.any().nullable().optional(),
+        phone: z.string().nullish(),
+        date_of_birth: z.string().nullish(),
+        billing_address: z.any().nullish(),
+        shipping_address: z.any().nullish(),
+        document: z.any().nullish(),
         browser_info: browserInfoSchema,
-        nationality: z.string().nullable().optional(),
-        device_fingerprint: z.any().nullable().optional(),
+        nationality: z.string().nullish(),
+        device_fingerprint: z.any().nullish(),
       })
       .passthrough(),
-    installment: z.any().nullable().optional(),
+    installment: z.any().nullish(),
     country: z.string(),
-    customer_session: z.any().nullable().optional(),
+    customer_session: z.any().nullish(),
   })
   .passthrough();
 
 const checkoutSessionCreateSchema = z
   .object({
-    account_id: z.string().min(36).max(64).describe("The unique identifier of the Yuno account").optional(),
-    customer_id: z.string().min(36).max(64).optional().describe("The unique identifier of the customer"),
+    account_id: z.string().min(36).max(64).describe("The unique identifier of the Yuno account").nullish(),
+    customer_id: z.string().min(36).max(64).nullish().describe("The unique identifier of the customer"),
     merchant_order_id: z.string().min(3).max(255).describe("The unique identifier of the customer's order"),
     payment_description: z.string().min(1).max(255).describe("The description of the payment"),
-    callback_url: z.string().min(3).max(526).optional().describe("The URL where we will redirect your customer after making the purchase"),
+    callback_url: z.string().min(3).max(526).nullish().describe("The URL where we will redirect your customer after making the purchase"),
     country: z.string().min(2).max(2).describe("The customer's country (ISO 3166-1)"),
-    amount: amountSchema.optional().describe("Specifies the payment amount object"),
+    amount: amountSchema.nullish().describe("Specifies the payment amount object"),
     alternative_amount: z
       .object({
-        currency: z.string().min(3).max(3).optional().nullable(),
-        value: z.number().optional(),
+        currency: z.string().min(3).max(3).nullish(),
+        value: z.number().nullish(),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("Alternative currency representation"),
-    workflow: z.enum(["SDK_CHECKOUT", "CHECKOUT", "SDK_SEAMLESS"]).optional().describe("Checkout workflow type"),
+    workflow: z.enum(["SDK_CHECKOUT", "CHECKOUT", "SDK_SEAMLESS"]).nullish().describe("Checkout workflow type"),
     metadata: metadataSchema,
     installments: z
       .object({
-        plan_id: z.string().optional().describe("Plan Id of the installment plan created in Yuno"),
+        plan_id: z.string().nullish().describe("Plan Id of the installment plan created in Yuno"),
         plan: z
           .array(
             z
@@ -107,11 +107,11 @@ const checkoutSessionCreateSchema = z
               })
               .passthrough(),
           )
-          .optional()
+          .nullish()
           .describe("Installments to show the customer"),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("The installment plan configuration"),
   })
   .passthrough();
@@ -129,32 +129,32 @@ const ottCreateSchema = z
             security_code: z.string().describe("Card security code (CVV)"),
             holder_name: z.string().describe("Cardholder name"),
           })
-          .optional(),
+          .nullish(),
         customer: z
           .object({
             browser_info: browserInfoSchema,
-            first_name: z.string().optional(),
-            last_name: z.string().optional(),
-            email: z.string().email().optional(),
-            gender: z.string().optional(),
-            date_of_birth: z.string().optional(),
-            document: documentSchema.optional(),
-            phone: phoneSchema.optional(),
-            billing_address: addressSchema.optional(),
-            shipping_address: addressSchema.optional(),
+            first_name: z.string().nullish(),
+            last_name: z.string().nullish(),
+            email: z.string().email().nullish(),
+            gender: z.string().nullish(),
+            date_of_birth: z.string().nullish(),
+            document: documentSchema.nullish(),
+            phone: phoneSchema.nullish(),
+            billing_address: addressSchema.nullish(),
+            shipping_address: addressSchema.nullish(),
           })
           .passthrough(),
-        vaulted_token: z.string().optional().nullable(),
+        vaulted_token: z.string().nullish(),
       })
       .passthrough(),
     three_d_secure: z
       .object({
-        three_d_secure_setup_id: z.string().optional().nullable().describe("3DS setup ID"),
+        three_d_secure_setup_id: z.string().nullish().describe("3DS setup ID"),
       })
       .passthrough(),
-    installment: z.any().optional().nullable().describe("Installment configuration"),
-    third_party_data: z.any().optional().nullable().describe("Third party data"),
-    device_fingerprints: z.any().optional().nullable().describe("Device fingerprints"),
+    installment: z.any().nullish().describe("Installment configuration"),
+    third_party_data: z.any().nullish().describe("Third party data"),
+    device_fingerprints: z.any().nullish().describe("Device fingerprints"),
   })
   .passthrough();
 

--- a/src/schemas/customers.ts
+++ b/src/schemas/customers.ts
@@ -3,32 +3,32 @@ import { addressSchema, metadataSchema, phoneSchema, documentSchema } from "./sh
 
 const yunoCustomerOutputSchema = z
   .object({
-    merchant_customer_id: z.string().optional(),
-    first_name: z.string().optional(),
-    last_name: z.string().optional(),
-    gender: z.string().optional(),
-    date_of_birth: z.string().optional(),
-    email: z.string().optional(),
+    merchant_customer_id: z.string().nullish(),
+    first_name: z.string().nullish(),
+    last_name: z.string().nullish(),
+    gender: z.string().nullish(),
+    date_of_birth: z.string().nullish(),
+    email: z.string().nullish(),
     document: documentSchema,
     phone: phoneSchema,
     billing_address: addressSchema,
     shipping_address: addressSchema,
     metadata: metadataSchema,
-    merchant_customer_created_at: z.string().optional(),
+    merchant_customer_created_at: z.string().nullish(),
   })
   .passthrough();
 
 const customerCreateSchema = z
   .object({
     merchant_customer_id: z.string().min(3).max(255),
-    merchant_customer_created_at: z.string().optional(),
-    first_name: z.string().min(3).max(255).optional(),
-    last_name: z.string().min(3).max(255).optional(),
-    gender: z.string().optional(),
-    date_of_birth: z.string().length(10).optional(),
-    email: z.string().min(3).max(255).optional(),
-    nationality: z.string().length(2).optional(),
-    country: z.string().length(2).optional(),
+    merchant_customer_created_at: z.string().nullish(),
+    first_name: z.string().min(3).max(255).nullish(),
+    last_name: z.string().min(3).max(255).nullish(),
+    gender: z.string().nullish(),
+    date_of_birth: z.string().length(10).nullish(),
+    email: z.string().min(3).max(255).nullish(),
+    nationality: z.string().length(2).nullish(),
+    country: z.string().length(2).nullish(),
     document: documentSchema,
     phone: phoneSchema,
     billing_address: addressSchema,
@@ -40,20 +40,20 @@ const customerCreateSchema = z
 const customerUpdateSchema = z
   .object({
     customerId: z.string().min(36).max(64).describe("The unique identifier of the customer to update (MIN 36, MAX 64 characters)"),
-    merchant_customer_id: z.string().min(3).max(255).optional(),
-    first_name: z.string().optional(),
-    last_name: z.string().optional(),
-    gender: z.string().optional(),
-    date_of_birth: z.string().optional(),
-    email: z.string().optional(),
-    nationality: z.string().optional(),
-    country: z.string().optional(),
+    merchant_customer_id: z.string().min(3).max(255).nullish(),
+    first_name: z.string().nullish(),
+    last_name: z.string().nullish(),
+    gender: z.string().nullish(),
+    date_of_birth: z.string().nullish(),
+    email: z.string().nullish(),
+    nationality: z.string().nullish(),
+    country: z.string().nullish(),
     document: documentSchema,
     phone: phoneSchema,
     billing_address: addressSchema,
     shipping_address: addressSchema,
     metadata: metadataSchema,
-    merchant_customer_created_at: z.string().optional(),
+    merchant_customer_created_at: z.string().nullish(),
   })
   .passthrough();
 

--- a/src/schemas/documentation.ts
+++ b/src/schemas/documentation.ts
@@ -27,13 +27,13 @@ const documentationReadSchema = z.object({
 
 const documentationIndexOutputSchema = z
   .object({
-    content: z.string().optional().describe("Raw llms.txt documentation index text"),
+    content: z.string().nullish().describe("Raw llms.txt documentation index text"),
   })
   .passthrough();
 
 const documentationReadOutputSchema = z
   .object({
-    content: z.string().optional().describe("Raw documentation page text"),
+    content: z.string().nullish().describe("Raw documentation page text"),
   })
   .passthrough();
 

--- a/src/schemas/installmentPlans.ts
+++ b/src/schemas/installmentPlans.ts
@@ -9,8 +9,8 @@ const financialCostSchema = z
 
 const installmentPlanCreateSchema = z
   .object({
-    name: z.string().describe("Name of the installment plan"),
-    account_id: z.array(z.string()).optional().describe("Account IDs for the plan"),
+    name: z.string().min(1).max(255).describe("Name of the installment plan"),
+    account_id: z.array(z.string()).nullish().describe("Account IDs for the plan"),
     merchant_reference: z.string().describe("Merchant reference for the plan"),
     installments_plan: z
       .array(
@@ -18,33 +18,32 @@ const installmentPlanCreateSchema = z
           .object({
             installment: z.number().int().describe("Number of monthly installments"),
             rate: z.number().describe("Rate applied to the final amount as a multiplier (e.g., 1.20 for 20%)"),
-            financial_costs: z.array(financialCostSchema).optional().describe("Financial costs for this installment option"),
-            type: z.enum(["MERCHANT_INSTALLMENTS", "ISSUER_INSTALLMENTS"]).optional().describe("Type of installment plan"),
+            financial_costs: z.array(financialCostSchema).nullish().describe("Financial costs for this installment option"),
+            type: z.enum(["MERCHANT_INSTALLMENTS", "ISSUER_INSTALLMENTS"]).nullish().describe("Type of installment plan"),
           })
           .passthrough(),
       )
       .describe("Installments to show the customer"),
-    country_code: z.string().min(2).max(2).optional().describe("Country code (ISO 3166-1 alpha-2)"),
-    brand: z.array(z.string()).optional().describe("Brands for the plan"),
-    issuer: z.string().optional().describe("Issuer for the plan"),
-    iin: z.array(z.string()).optional().describe("IINs for the plan"),
-    first_installment_deferral: z.number().int().max(3).optional().describe("Months to wait before first installment"),
+    country_code: z.string().min(2).max(2).describe("Country code (ISO 3166-1 alpha-2)"),
+    brand: z.array(z.string()).nullish().describe("Brands for the plan"),
+    issuer: z.string().nullish().describe("Issuer for the plan"),
+    iin: z.array(z.string()).nullish().describe("IINs for the plan"),
+    first_installment_deferral: z.number().int().max(3).nullish().describe("Months to wait before first installment"),
     amount: z
       .object({
         currency: z.string().min(3).max(3),
-        min_value: z.number().optional(),
-        max_value: z.number().optional(),
+        min_value: z.number().nullish(),
+        max_value: z.number().nullish(),
       })
       .passthrough()
-      .optional()
       .describe("Amount limits for the plan"),
     availability: z
       .object({
-        start_at: z.string().optional(),
-        finish_at: z.string().optional(),
+        start_at: z.string().nullish(),
+        finish_at: z.string().nullish(),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("Availability period for the plan"),
   })
   .passthrough();
@@ -52,49 +51,49 @@ const installmentPlanCreateSchema = z
 const installmentPlanUpdateSchema = z
   .object({
     planId: z.string().describe("The unique identifier of the installment plan to update"),
-    name: z.string().optional(),
-    account_id: z.array(z.string()).optional().describe("Account IDs for the plan"),
-    merchant_reference: z.string().optional(),
+    name: z.string().nullish(),
+    account_id: z.array(z.string()).nullish().describe("Account IDs for the plan"),
+    merchant_reference: z.string().nullish(),
     installments_plan: z
       .array(
         z
           .object({
-            installment: z.number().int().optional(),
-            rate: z.number().optional(),
-            financial_costs: z.array(financialCostSchema).optional(),
-            type: z.enum(["MERCHANT_INSTALLMENTS", "ISSUER_INSTALLMENTS"]).optional(),
+            installment: z.number().int().nullish(),
+            rate: z.number().nullish(),
+            financial_costs: z.array(financialCostSchema).nullish(),
+            type: z.enum(["MERCHANT_INSTALLMENTS", "ISSUER_INSTALLMENTS"]).nullish(),
           })
           .passthrough(),
       )
-      .optional(),
-    country_code: z.string().min(2).max(2).optional(),
-    scheme: z.string().optional().describe("Card's scheme information"),
-    brand: z.array(z.string()).optional(),
-    issuer: z.string().optional(),
-    iin: z.array(z.string()).optional(),
-    first_installment_deferral: z.number().int().max(3).optional(),
+      .nullish(),
+    country_code: z.string().min(2).max(2).nullish(),
+    scheme: z.string().nullish().describe("Card's scheme information"),
+    brand: z.array(z.string()).nullish(),
+    issuer: z.string().nullish(),
+    iin: z.array(z.string()).nullish(),
+    first_installment_deferral: z.number().int().max(3).nullish(),
     amount: z
       .object({
-        currency: z.string().min(3).max(3).optional(),
-        min_value: z.number().optional(),
-        max_value: z.number().optional(),
+        currency: z.string().min(3).max(3).nullish(),
+        min_value: z.number().nullish(),
+        max_value: z.number().nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     availability: z
       .object({
-        start_at: z.string().optional(),
-        finish_at: z.string().optional(),
+        start_at: z.string().nullish(),
+        finish_at: z.string().nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
   })
   .passthrough();
 
 const yunoInstallmentPlanOutputSchema = z
   .object({
     name: z.string(),
-    account_id: z.array(z.string()).optional(),
+    account_id: z.array(z.string()).nullish(),
     merchant_reference: z.string(),
     installments_plan: z
       .array(
@@ -111,32 +110,38 @@ const yunoInstallmentPlanOutputSchema = z
                   })
                   .passthrough(),
               )
-              .optional(),
-            type: z.enum(["MERCHANT_INSTALLMENTS", "ISSUER_INSTALLMENTS"]).optional(),
+              .nullish(),
+            type: z.string().nullish(),
           })
           .passthrough(),
       )
-      .optional(),
-    country_code: z.string().optional(),
-    brand: z.array(z.string()).optional(),
-    issuer: z.string().optional(),
-    iin: z.array(z.string()).optional(),
-    first_installment_deferral: z.number().optional(),
+      .nullish(),
+    country_code: z.string().nullish(),
+    brand: z.array(z.string()).nullish(),
+    issuer: z.string().nullish(),
+    iin: z.array(z.string()).nullish(),
+    first_installment_deferral: z.number().nullish(),
     amount: z
       .object({
-        currency: z.string(),
-        min_value: z.number().optional(),
-        max_value: z.number().optional(),
+        currency: z.string().nullish(),
+        min_value: z.number().nullish(),
+        max_value: z.number().nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     availability: z
       .object({
-        start_at: z.string().optional(),
-        finish_at: z.string().optional(),
+        start_at: z.string().nullish(),
+        finish_at: z.string().nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
+  })
+  .passthrough();
+
+const yunoInstallmentPlanListOutputSchema = z
+  .object({
+    items: z.array(yunoInstallmentPlanOutputSchema).nullish(),
   })
   .passthrough();
 
@@ -144,4 +149,5 @@ export {
   installmentPlanCreateSchema,
   installmentPlanUpdateSchema,
   yunoInstallmentPlanOutputSchema,
+  yunoInstallmentPlanListOutputSchema,
 };

--- a/src/schemas/paymentLinks.ts
+++ b/src/schemas/paymentLinks.ts
@@ -3,13 +3,13 @@ import { addressSchema, amountSchema, documentSchema, metadataSchema, phoneSchem
 
 const yunoPaymentLinkOutputSchema = z
   .object({
-    account_id: z.string().optional(),
-    description: z.string().optional(),
+    account_id: z.string().nullish(),
+    description: z.string().nullish(),
     country: z.string(),
-    merchant_order_id: z.string().optional(),
-    additional_data: z.any().optional(),
-    url: z.string().optional(),
-    status: z.string().optional(),
+    merchant_order_id: z.string().nullish(),
+    additional_data: z.any().nullish(),
+    url: z.string().nullish(),
+    status: z.string().nullish(),
     amount: z
       .object({
         currency: z.string(),
@@ -18,68 +18,68 @@ const yunoPaymentLinkOutputSchema = z
       .passthrough(),
     payment_method_types: z.array(z.string()),
     metadata: metadataSchema,
-    cancelled_at: z.string().optional(),
+    cancelled_at: z.string().nullish(),
   })
   .passthrough();
 
 const customerPayerSchema = z
   .object({
-    id: z.string().min(36).max(64).optional().describe("The unique identifier of the customer in uuid v4 format"),
-    merchant_customer_id: z.string().min(3).max(255).optional().describe("The unique identifier for a customer in the merchant's system"),
-    first_name: z.string().min(1).max(255).optional().describe("The customer's first name"),
-    last_name: z.string().min(1).max(255).optional().describe("The customer's last name"),
-    gender: z.string().min(1).max(2).optional().describe("The customer's gender (M/F/NA/NK)"),
-    date_of_birth: z.string().length(10).optional().describe("The customer's date of birth in the YYYY-MM-DD format"),
-    email: z.string().min(3).max(255).optional().describe("The customer's e-mail"),
-    nationality: z.string().length(2).optional().describe("The customer's nationality (ISO 3166-1)"),
-    document: documentSchema.optional(),
-    billing_address: addressSchema.optional(),
-    shipping_address: addressSchema.optional(),
-    phone: phoneSchema.optional(),
-    ip_address: z.string().min(1).max(45).optional().describe("The customer's IP address"),
+    id: z.string().min(36).max(64).nullish().describe("The unique identifier of the customer in uuid v4 format"),
+    merchant_customer_id: z.string().min(3).max(255).nullish().describe("The unique identifier for a customer in the merchant's system"),
+    first_name: z.string().min(1).max(255).nullish().describe("The customer's first name"),
+    last_name: z.string().min(1).max(255).nullish().describe("The customer's last name"),
+    gender: z.string().min(1).max(2).nullish().describe("The customer's gender (M/F/NA/NK)"),
+    date_of_birth: z.string().length(10).nullish().describe("The customer's date of birth in the YYYY-MM-DD format"),
+    email: z.string().min(3).max(255).nullish().describe("The customer's e-mail"),
+    nationality: z.string().length(2).nullish().describe("The customer's nationality (ISO 3166-1)"),
+    document: documentSchema.nullish(),
+    billing_address: addressSchema.nullish(),
+    shipping_address: addressSchema.nullish(),
+    phone: phoneSchema.nullish(),
+    ip_address: z.string().min(1).max(45).nullish().describe("The customer's IP address"),
   })
   .passthrough();
 
 const paymentLinkCreateSchema = z
   .object({
-    account_id: z.string().optional().describe("Account ID for the payment"),
-    description: z.string().max(255).optional().describe("The description of the payment"),
+    account_id: z.string().nullish().describe("Account ID for the payment"),
+    description: z.string().min(1).max(255).describe("The description of the payment"),
     country: z.string().min(2).max(2).describe("Country (ISO 3166-1)"),
-    merchant_order_id: z.string().min(3).max(255).optional().describe("The unique identifier of the customer's order"),
+    merchant_order_id: z.string().min(3).max(255).nullish().describe("The unique identifier of the customer's order"),
     amount: amountSchema.describe("Specifies the payment amount object"),
-    capture: z.boolean().optional().describe("Whether to capture the payment immediately, true by default"),
-    type: z.string().optional().describe("Payment link classification"),
-    payment_method: z.any().optional().describe("Payment method configuration"),
-    installments_plan: z.any().optional().describe("Installment arrangement details"),
-    timezone: z.string().optional().describe("Availability timezone (e.g., UTC +03:00)"),
-    payments_number: z.number().int().optional().describe("Count of linked payments"),
-    split_payment_methods: z.boolean().optional().describe("Enable divided payment options"),
+    capture: z.boolean().nullish().describe("Whether to capture the payment immediately, true by default"),
+    type: z.string().nullish().describe("Payment link classification"),
+    payment_method: z.any().nullish().describe("Payment method configuration"),
+    installments_plan: z.any().nullish().describe("Installment arrangement details"),
+    timezone: z.string().nullish().describe("Availability timezone (e.g., UTC +03:00)"),
+    payments_number: z.number().int().nullish().describe("Count of linked payments"),
+    split_payment_methods: z.boolean().nullish().describe("Enable divided payment options"),
     taxes: z
       .array(
         z
           .object({
             type: z.string(),
             value: z.number(),
-            tax_base: z.number().optional(),
-            percentage: z.number().optional(),
+            tax_base: z.number().nullish(),
+            percentage: z.number().nullish(),
           })
           .passthrough(),
       )
-      .optional(),
-    customer_payer: customerPayerSchema.optional(),
-    additional_data: z.any().optional(),
-    callback_url: z.string().optional(),
-    one_time_use: z.boolean().optional(),
+      .nullish(),
+    customer_payer: customerPayerSchema.nullish(),
+    additional_data: z.any().nullish(),
+    callback_url: z.string().nullish(),
+    one_time_use: z.boolean().nullish(),
     availability: z
       .object({
-        start_at: z.string().optional(),
-        finish_at: z.string().optional(),
+        start_at: z.string().nullish(),
+        finish_at: z.string().nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     payment_method_types: z.array(z.string()),
     metadata: metadataSchema,
-    vault_on_success: z.boolean().optional(),
+    vault_on_success: z.boolean().nullish(),
   })
   .passthrough();
 

--- a/src/schemas/paymentMethods.ts
+++ b/src/schemas/paymentMethods.ts
@@ -7,42 +7,48 @@ const paymentMethodEnrollSchema = z
       .string()
       .min(36)
       .max(64)
-      .optional()
+      .nullish()
       .describe("The unique identifier of the account. You find this information on Yuno's Dashboard (MAX 64; MIN 36)."),
     country: z.string().min(2).max(2).describe("The transaction's country code (ISO 3166-1)."),
     type: z.string().min(3).max(255).describe("The payment method type (MAX 255; MIN 3; e.g. 'CARD', 'NU_PAY_ENROLLMENT')."),
-    workflow: z.enum(["DIRECT"]).optional().describe("The payment workflow. For direct integration, use 'DIRECT'."),
+    workflow: z.enum(["DIRECT"]).nullish().describe("The payment workflow. For direct integration, use 'DIRECT'."),
     provider_data: z
       .object({
         id: z.string(),
         payment_method_token: z.string(),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("Provider data for token migration, only if agreed with Yuno."),
-    card_data: cardDataSchema.optional().describe("Card details for DIRECT workflow (PCI merchants only)."),
-    callback_url: z.string().min(3).max(255).optional().describe("URL to return the customer after enrollment (for APMs)."),
+    card_data: cardDataSchema.nullish().describe("Card details for DIRECT workflow (PCI merchants only)."),
+    callback_url: z.string().min(3).max(255).nullish().describe("URL to return the customer after enrollment (for APMs)."),
     verify: z
       .object({
         vault_on_success: z.boolean(),
-        currency: z.string().optional(),
+        currency: z.string().nullish(),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("Indicates whether to verify the payment with a verify transaction or not. null if not specified."),
   })
   .passthrough();
 
 const yunoPaymentMethodOutputSchema = z
   .object({
-    name: z.string().optional(),
-    description: z.string().optional(),
-    type: z.string().optional(),
-    country: z.string().optional(),
-    status: z.string().optional(),
-    sub_status: z.string().optional(),
-    vaulted_token: z.string().optional(),
+    name: z.string().nullish(),
+    description: z.string().nullish(),
+    type: z.string().nullish(),
+    country: z.string().nullish(),
+    status: z.string().nullish(),
+    sub_status: z.string().nullish(),
+    vaulted_token: z.string().nullish(),
   })
   .passthrough();
 
-export { paymentMethodEnrollSchema, yunoPaymentMethodOutputSchema };
+const yunoPaymentMethodListOutputSchema = z
+  .object({
+    payment_methods: z.array(yunoPaymentMethodOutputSchema).nullish(),
+  })
+  .passthrough();
+
+export { paymentMethodEnrollSchema, yunoPaymentMethodOutputSchema, yunoPaymentMethodListOutputSchema };

--- a/src/schemas/payments.ts
+++ b/src/schemas/payments.ts
@@ -3,60 +3,60 @@ import { addressSchema, amountSchema, cardDataSchema, documentSchema, metadataSc
 
 const customerPayerSchema = z
   .object({
-    id: z.string().min(36).max(64).optional().describe("The unique identifier of the customer in uuid v4 format (MAX 64 ; MIN 36)"),
-    merchant_customer_id: z.string().min(1).max(255).optional().describe("The unique identifier for a customer in the merchant's system"),
+    id: z.string().min(36).max(64).nullish().describe("The unique identifier of the customer in uuid v4 format (MAX 64 ; MIN 36)"),
+    merchant_customer_id: z.string().min(1).max(255).nullish().describe("The unique identifier for a customer in the merchant's system"),
     merchant_customer_created_at: z
       .string()
       .min(27)
       .max(27)
-      .optional()
+      .nullish()
       .describe("Customer´s registration date on the merchants platform (ISO 8601)"),
-    first_name: z.string().min(1).max(255).optional().describe("The customer's first name"),
-    last_name: z.string().min(1).max(255).optional().describe("The customer's last name"),
-    gender: z.string().min(1).max(2).optional().describe("The customer's gender (M/F/NB/NA/NK/U)"),
-    date_of_birth: z.string().length(10).optional().describe("The customer's date of birth in the YYYY-MM-DD format"),
-    email: z.string().min(1).max(255).optional().describe("The customer's e-mail"),
-    nationality: z.string().length(2).optional().describe("The customer's nationality (ISO 3166-1)"),
-    ip_address: z.string().min(1).max(45).optional().describe("The customer's IP address"),
+    first_name: z.string().min(1).max(255).nullish().describe("The customer's first name"),
+    last_name: z.string().min(1).max(255).nullish().describe("The customer's last name"),
+    gender: z.string().min(1).max(2).nullish().describe("The customer's gender (M/F/NB/NA/NK/U)"),
+    date_of_birth: z.string().length(10).nullish().describe("The customer's date of birth in the YYYY-MM-DD format"),
+    email: z.string().min(1).max(255).nullish().describe("The customer's e-mail"),
+    nationality: z.string().length(2).nullish().describe("The customer's nationality (ISO 3166-1)"),
+    ip_address: z.string().min(1).max(45).nullish().describe("The customer's IP address"),
     device_fingerprints: z
       .array(
         z
           .object({
-            provider_id: z.string().describe("The fraud screening provider id").optional(),
-            id: z.string().describe("The device fingerprint associated to the provider").optional(),
+            provider_id: z.string().describe("The fraud screening provider id").nullish(),
+            id: z.string().describe("The device fingerprint associated to the provider").nullish(),
           })
           .passthrough(),
       )
       .max(4000)
-      .optional(),
+      .nullish(),
     browser_info: z
       .object({
-        user_agent: z.string().min(3).max(255).optional(),
-        accept_header: z.string().optional(),
-        platform: z.string().optional(),
-        color_depth: z.string().min(1).max(5).optional(),
-        screen_height: z.string().min(3).max(255).optional(),
-        screen_width: z.string().min(3).max(255).optional(),
-        javascript_enabled: z.boolean().optional(),
-        language: z.string().min(1).max(5).optional(),
-        accept_browser: z.string().optional(),
-        accept_content: z.string().optional(),
-        java_enabled: z.boolean().optional(),
-        browser_time_difference: z.string().optional(),
+        user_agent: z.string().min(3).max(255).nullish(),
+        accept_header: z.string().nullish(),
+        platform: z.string().nullish(),
+        color_depth: z.string().min(1).max(5).nullish(),
+        screen_height: z.string().min(3).max(255).nullish(),
+        screen_width: z.string().min(3).max(255).nullish(),
+        javascript_enabled: z.boolean().nullish(),
+        language: z.string().min(1).max(5).nullish(),
+        accept_browser: z.string().nullish(),
+        accept_content: z.string().nullish(),
+        java_enabled: z.boolean().nullish(),
+        browser_time_difference: z.string().nullish(),
       })
       .passthrough()
-      .optional(),
-    document: documentSchema.optional(),
-    billing_address: addressSchema.optional(),
-    shipping_address: addressSchema.optional(),
-    phone: phoneSchema.optional(),
+      .nullish(),
+    document: documentSchema.nullish(),
+    billing_address: addressSchema.nullish(),
+    shipping_address: addressSchema.nullish(),
+    phone: phoneSchema.nullish(),
     geolocation: z
       .object({
-        latitude: z.string().min(1).max(11).optional(),
-        longitude: z.string().min(1).max(11).optional(),
+        latitude: z.string().min(1).max(11).nullish(),
+        longitude: z.string().min(1).max(11).nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
   })
   .passthrough();
 
@@ -64,103 +64,110 @@ const paymentCreateSchema = z
   .object({
     payment: z
       .object({
-        account_id: z.string().optional().describe("Account ID for the payment"),
+        account_id: z.string().nullish().describe("Account ID for the payment"),
         description: z.string().describe("Payment description"),
-        additional_data: z.any().optional(),
+        additional_data: z.any().nullish(),
         country: z.string().describe("Customer's country (ISO 3166-1)"),
         merchant_order_id: z.string().describe("Unique identifier for the order"),
-        merchant_reference: z.string().optional(),
+        merchant_reference: z.string().nullish(),
         amount: amountSchema.describe("Payment amount details"),
-        customer_payer: customerPayerSchema.describe("Customer payer info").optional(),
+        customer_payer: customerPayerSchema.describe("Customer payer info").nullish(),
         checkout: z
           .object({
             session: z.string().describe("The checkout session ID"),
           })
           .passthrough()
-          .optional()
+          .nullish()
           .describe("Checkout session information"),
         workflow: z.enum(["SDK_CHECKOUT", "DIRECT", "REDIRECT"]).describe("Payment workflow type"),
         payment_method: z
           .object({
-            token: z.string().optional(),
-            vaulted_token: z.string().optional(),
+            token: z.string().nullish(),
+            vaulted_token: z.string().nullish(),
             type: z.string().describe("Payment method type"),
             detail: z
               .object({
                 card: z
                   .object({
-                    capture: z.boolean().optional(),
-                    installments: z.number().optional(),
-                    first_installment_deferral: z.number().optional(),
-                    soft_descriptor: z.string().optional(),
-                    card_data: cardDataSchema.optional(),
-                    verify: z.boolean().optional(),
+                    capture: z.boolean().nullish(),
+                    installments: z.number().nullish(),
+                    first_installment_deferral: z.number().nullish(),
+                    soft_descriptor: z.string().nullish(),
+                    card_data: cardDataSchema.nullish(),
+                    verify: z.boolean().nullish(),
                     stored_credentials: z
                       .object({
-                        reason: z.string().optional(),
-                        usage: z.string().optional(),
-                        subscription_agreement_id: z.string().optional(),
-                        network_transaction_id: z.string().optional(),
+                        reason: z.string().nullish(),
+                        usage: z.string().nullish(),
+                        subscription_agreement_id: z.string().nullish(),
+                        network_transaction_id: z.string().nullish(),
                       })
                       .passthrough()
-                      .optional(),
+                      .nullish(),
                   })
                   .passthrough()
-                  .optional(),
+                  .nullish(),
               })
               .passthrough()
-              .optional(),
-            vault_on_success: z.boolean().optional(),
+              .nullish(),
+            vault_on_success: z.boolean().nullish(),
           })
           .passthrough()
           .describe("Payment method details"),
-        callback_url: z.string().optional(),
-        fraud_screening: z.any().optional(),
-        split_marketplace: z.any().optional(),
+        callback_url: z.string().nullish(),
+        fraud_screening: z.any().nullish(),
+        split_marketplace: z.any().nullish(),
         metadata: metadataSchema,
       })
-      .passthrough(),
-    idempotencyKey: z.string().uuid().optional().describe("Unique key to prevent duplicate payments"),
+      .passthrough()
+      .refine(
+        (payment) => payment.workflow !== "SDK_CHECKOUT" || (payment.checkout != null && payment.checkout.session != null),
+        {
+          message: "checkout.session is required when workflow is SDK_CHECKOUT",
+          path: ["checkout", "session"],
+        },
+      ),
+    idempotencyKey: z.string().uuid().nullish().describe("Unique key to prevent duplicate payments"),
   })
   .passthrough();
 
 const operationPaymentResponseAdditionalDataSchema = z
   .object({
-    receipt: z.boolean().optional(),
-    receipt_language: z.enum(["ES", "EN", "PT"]).optional(),
+    receipt: z.boolean().nullish(),
+    receipt_language: z.enum(["ES", "EN", "PT"]).nullish(),
   })
   .passthrough()
-  .optional();
+  .nullish();
 
 const paymentRefundSchema = z
   .object({
-    description: z.string().min(3).max(255).optional(),
-    reason: z.enum(["DUPLICATE", "FRAUDULENT", "REQUESTED_BY_CUSTOMER"]).optional(),
+    description: z.string().min(3).max(255).nullish(),
+    reason: z.enum(["DUPLICATE", "FRAUDULENT", "REQUESTED_BY_CUSTOMER"]).nullish(),
     merchant_reference: z.string().min(3).max(255),
     amount: z
       .object({
-        currency: z.string().min(3).max(3).optional(),
-        value: z.number().optional(),
+        currency: z.string().min(3).max(3).nullish(),
+        value: z.number().nullish(),
       })
       .passthrough()
-      .optional(),
-    simplified_mode: z.boolean().optional(),
+      .nullish(),
+    simplified_mode: z.boolean().nullish(),
     response_additional_data: operationPaymentResponseAdditionalDataSchema,
     customer_payer: z
       .object({
-        first_name: z.string().min(3).max(255).optional().describe("First name of the customer"),
-        last_name: z.string().min(3).max(255).optional().describe("Last name of the customer"),
-        gender: z.string().optional().describe("Gender of the customer (M/F/NB/NA/NK/U)"),
-        date_of_birth: z.string().length(10).optional().describe("Date of birth (YYYY-MM-DD)"),
-        email: z.string().min(3).max(255).optional().describe("Email of the customer"),
-        nationality: z.string().length(2).optional().describe("Nationality (ISO 3166-1)"),
-        document: documentSchema.optional(),
-        phone: phoneSchema.optional(),
-        billing_address: addressSchema.optional(),
-        shipping_address: addressSchema.optional(),
+        first_name: z.string().min(3).max(255).nullish().describe("First name of the customer"),
+        last_name: z.string().min(3).max(255).nullish().describe("Last name of the customer"),
+        gender: z.string().nullish().describe("Gender of the customer (M/F/NB/NA/NK/U)"),
+        date_of_birth: z.string().length(10).nullish().describe("Date of birth (YYYY-MM-DD)"),
+        email: z.string().min(3).max(255).nullish().describe("Email of the customer"),
+        nationality: z.string().length(2).nullish().describe("Nationality (ISO 3166-1)"),
+        document: documentSchema.nullish(),
+        phone: phoneSchema.nullish(),
+        billing_address: addressSchema.nullish(),
+        shipping_address: addressSchema.nullish(),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("Customer payer info"),
     payment_method: z
       .object({
@@ -168,31 +175,31 @@ const paymentRefundSchema = z
           .object({
             bank_transfer: z
               .object({
-                account_type: z.enum(["CHECKINGS", "SAVINGS"]).optional(),
-                bank_name: z.string().optional(),
-                bank_id: z.string().optional(),
-                beneficiary_name: z.string().optional(),
-                bank_account: z.string().optional(),
-                beneficiary_document_type: z.string().optional(),
-                beneficiary_document: z.string().optional(),
-                reference: z.string().optional(),
+                account_type: z.enum(["CHECKINGS", "SAVINGS"]).nullish(),
+                bank_name: z.string().nullish(),
+                bank_id: z.string().nullish(),
+                beneficiary_name: z.string().nullish(),
+                bank_account: z.string().nullish(),
+                beneficiary_document_type: z.string().nullish(),
+                beneficiary_document: z.string().nullish(),
+                reference: z.string().nullish(),
               })
               .passthrough()
-              .optional(),
+              .nullish(),
           })
           .passthrough()
-          .optional(),
+          .nullish(),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("Payment method details for the refund"),
   })
   .passthrough();
 
 const paymentCancelSchema = z
   .object({
-    description: z.string().min(3).max(255).optional(),
-    reason: z.enum(["DUPLICATE", "FRAUDULENT", "REQUESTED_BY_CUSTOMER"]).optional(),
+    description: z.string().min(3).max(255).nullish(),
+    reason: z.enum(["DUPLICATE", "FRAUDULENT", "REQUESTED_BY_CUSTOMER"]).nullish(),
     merchant_reference: z.string().min(3).max(255),
     response_additional_data: operationPaymentResponseAdditionalDataSchema,
   })
@@ -206,107 +213,106 @@ const paymentCaptureAuthorizationSchema = z
         currency: z.string().min(3).max(3),
         value: z.number(),
       })
-      .passthrough()
-      .optional(),
+      .passthrough(),
     reason: z.string().min(3).max(255),
-    simplified_mode: z.boolean().optional(),
+    simplified_mode: z.boolean().nullish(),
   })
   .passthrough();
 
 const yunoPaymentOutputSchema = z
   .object({
-    account_id: z.string().optional(),
-    description: z.string().optional(),
-    additional_data: z.any().optional(),
-    country: z.string().optional(),
-    merchant_order_id: z.string().optional(),
-    merchant_reference: z.string().optional(),
-    amount: amountSchema.optional(),
+    account_id: z.string().nullish(),
+    description: z.string().nullish(),
+    additional_data: z.any().nullish(),
+    country: z.string().nullish(),
+    merchant_order_id: z.string().nullish(),
+    merchant_reference: z.string().nullish(),
+    amount: amountSchema.nullish(),
     customer_payer: z
       .object({
-        id: z.string().optional(),
-        first_name: z.string().optional(),
-        last_name: z.string().optional(),
-        email: z.string().optional(),
+        id: z.string().nullish(),
+        first_name: z.string().nullish(),
+        last_name: z.string().nullish(),
+        email: z.string().nullish(),
       })
       .passthrough()
-      .optional(),
-    workflow: z.string().optional(),
+      .nullish(),
+    workflow: z.string().nullish(),
     payment_method: z
       .object({
-        token: z.string().optional(),
-        vaulted_token: z.string().optional(),
-        type: z.string().optional(),
+        token: z.string().nullish(),
+        vaulted_token: z.string().nullish(),
+        type: z.string().nullish(),
         detail: z
           .object({
             card: z
               .object({
-                capture: z.boolean().optional(),
-                installments: z.number().optional(),
-                first_installment_deferral: z.number().optional(),
-                soft_descriptor: z.string().optional(),
+                capture: z.boolean().nullish(),
+                installments: z.number().nullish(),
+                first_installment_deferral: z.number().nullish(),
+                soft_descriptor: z.string().nullish(),
                 card_data: z
                   .object({
-                    number: z.string().optional(),
-                    expiration_month: z.number().optional(),
-                    expiration_year: z.number().optional(),
-                    security_code: z.string().optional(),
-                    holder_name: z.string().optional(),
-                    type: z.string().optional(),
+                    number: z.string().nullish(),
+                    expiration_month: z.number().nullish(),
+                    expiration_year: z.number().nullish(),
+                    security_code: z.string().nullish(),
+                    holder_name: z.string().nullish(),
+                    type: z.string().nullish(),
                   })
                   .passthrough()
-                  .optional(),
-                verify: z.boolean().optional(),
+                  .nullish(),
+                verify: z.boolean().nullish(),
                 stored_credentials: z
                   .object({
-                    reason: z.string().optional(),
-                    usage: z.string().optional(),
-                    subscription_agreement_id: z.string().optional(),
-                    network_transaction_id: z.string().optional(),
+                    reason: z.string().nullish(),
+                    usage: z.string().nullish(),
+                    subscription_agreement_id: z.string().nullish(),
+                    network_transaction_id: z.string().nullish(),
                   })
                   .passthrough()
-                  .optional(),
+                  .nullish(),
               })
               .passthrough()
-              .optional(),
+              .nullish(),
           })
           .passthrough()
-          .optional(),
-        vault_on_success: z.boolean().optional(),
+          .nullish(),
+        vault_on_success: z.boolean().nullish(),
       })
       .passthrough()
-      .optional(),
-    callback_url: z.string().optional(),
+      .nullish(),
+    callback_url: z.string().nullish(),
     fraud_screening: z
-      .object({ stand_alone: z.boolean().optional() })
+      .object({ stand_alone: z.boolean().nullish() })
       .passthrough()
-      .optional(),
+      .nullish(),
     split_marketplace: z
       .array(
         z
           .object({
-            recipient_id: z.string().optional(),
-            provider_recipient_id: z.string().optional(),
-            type: z.string().optional(),
-            merchant_reference: z.string().optional(),
+            recipient_id: z.string().nullish(),
+            provider_recipient_id: z.string().nullish(),
+            type: z.string().nullish(),
+            merchant_reference: z.string().nullish(),
             amount: z
               .object({
-                value: z.number().optional(),
-                currency: z.string().optional(),
+                value: z.number().nullish(),
+                currency: z.string().nullish(),
               })
               .passthrough()
-              .optional(),
+              .nullish(),
             liability: z
               .object({
-                processing_fee: z.string().optional(),
-                chargebacks: z.boolean().optional(),
+                processing_fee: z.string().nullish(),
+                chargebacks: z.boolean().nullish(),
               })
               .passthrough()
-              .optional(),
+              .nullish(),
           })
           .passthrough(),
       )
-      .optional(),
+      .nullish(),
     metadata: metadataSchema,
   })
   .passthrough();

--- a/src/schemas/recipients.ts
+++ b/src/schemas/recipients.ts
@@ -3,16 +3,16 @@ import { addressSchema, documentSchema, phoneSchema } from "./shared";
 
 const legalRepresentativeSchema = z
   .object({
-    merchant_reference: z.string().optional(),
-    first_name: z.string().optional(),
-    last_name: z.string().optional(),
-    email: z.string().optional(),
-    date_of_birth: z.string().optional(),
-    country: z.string().min(2).max(2).optional(),
-    nationality: z.string().min(2).max(2).optional(),
-    title: z.string().optional(),
-    publicly_exposed_person: z.boolean().optional(),
-    ultimate_beneficial_owner: z.boolean().optional(),
+    merchant_reference: z.string().nullish(),
+    first_name: z.string().nullish(),
+    last_name: z.string().nullish(),
+    email: z.string().nullish(),
+    date_of_birth: z.string().nullish(),
+    country: z.string().min(2).max(2).nullish(),
+    nationality: z.string().min(2).max(2).nullish(),
+    title: z.string().nullish(),
+    publicly_exposed_person: z.boolean().nullish(),
+    ultimate_beneficial_owner: z.boolean().nullish(),
   })
   .passthrough();
 
@@ -20,14 +20,14 @@ const withdrawalMethodsBankSchema = z
   .object({
     code: z.string().min(3).max(3),
     branch: z.string().min(3).max(3),
-    branch_digit: z.string().min(3).max(3).optional(),
+    branch_digit: z.string().min(3).max(3).nullish(),
     account: z.string().min(3).max(250),
-    account_digit: z.string().min(3).max(250).optional(),
+    account_digit: z.string().min(3).max(250).nullish(),
     account_type: z.enum(["CHECKINGS", "SAVINGS"]),
-    routing: z.string().optional(),
+    routing: z.string().nullish(),
     country: z.string().min(2).max(2),
     currency: z.string().min(3).max(3),
-    payout_schedule: z.enum(["DAY", "WEEK", "MONTH", "HOLD"]).optional(),
+    payout_schedule: z.enum(["DAY", "WEEK", "MONTH", "HOLD"]).nullish(),
   })
   .passthrough();
 
@@ -42,68 +42,68 @@ const documentationItemSchema = z
 
 const onboardingSchema = z
   .object({
-    account_id: z.string().optional(),
+    account_id: z.string().nullish(),
     type: z.enum(["PREVIOUSLY_ONBOARDED", "ONBOARD_ONTO_THE_PROVIDER"]),
     workflow: z.enum(["HOSTED_BY_PROVIDER", "DIRECT"]),
-    description: z.string().optional(),
-    callback_url: z.string().optional(),
+    description: z.string().nullish(),
+    callback_url: z.string().nullish(),
     provider: z
       .object({
         id: z.string().describe("Provider ID (e.g., PAGARME, STRIPE, ADYEN)"),
         connection_id: z.string(),
-        recipient_id: z.string().optional(),
-        recipient_type: z.enum(["MEAL", "FOOD", "MULTI_BENEFITS", "FLEET"]).optional(),
+        recipient_id: z.string().nullish(),
+        recipient_type: z.enum(["MEAL", "FOOD", "MULTI_BENEFITS", "FLEET"]).nullish(),
       })
       .passthrough(),
-    documentation: z.array(documentationItemSchema).optional(),
+    documentation: z.array(documentationItemSchema).nullish(),
     withdrawal_methods: z
       .object({
-        bank: withdrawalMethodsBankSchema.optional(),
+        bank: withdrawalMethodsBankSchema.nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
   })
   .passthrough();
 
 const recipientCreateSchema = z
   .object({
-    account_id: z.string().min(36).max(64).optional().describe("Account ID for the recipient"),
-    merchant_recipient_id: z.string().optional().describe("The unique identifier for the recipient in the merchant system"),
+    account_id: z.string().min(36).max(64).nullish().describe("Account ID for the recipient"),
+    merchant_recipient_id: z.string().describe("The unique identifier for the recipient in the merchant system"),
     national_entity: z.enum(["INDIVIDUAL", "ENTITY"]).describe("Beneficiary's national entity type. Could be INDIVIDUAL or ENTITY"),
     entity_type: z
       .enum(["GOVERNMENTAL", "PUBLIC", "NON_PROFIT", "PRIVATE"])
-      .optional()
+      .nullish()
       .describe("The Beneficiary's type of organization"),
-    first_name: z.string().optional().describe("First name of the recipient"),
-    last_name: z.string().optional().describe("Last name of the recipient"),
-    date_of_birth: z.string().optional().describe("Date of birth of the recipient (YYYY-MM-DD)"),
-    legal_name: z.string().optional().describe("Legal name of the recipient (required for ENTITY)"),
-    email: z.string().email().optional().describe("Email of the recipient"),
-    country: z.string().min(2).max(2).optional().describe("Country code (ISO 3166-1)"),
-    website: z.string().optional().describe("Seller website URL"),
-    industry: z.string().optional().describe("Industry category"),
-    merchant_category_code: z.string().optional().describe("MCC code"),
+    first_name: z.string().nullish().describe("First name of the recipient"),
+    last_name: z.string().nullish().describe("Last name of the recipient"),
+    date_of_birth: z.string().nullish().describe("Date of birth of the recipient (YYYY-MM-DD)"),
+    legal_name: z.string().nullish().describe("Legal name of the recipient (required for ENTITY)"),
+    email: z.string().email().nullish().describe("Email of the recipient"),
+    country: z.string().min(2).max(2).describe("Country code (ISO 3166-1)"),
+    website: z.string().nullish().describe("Seller website URL"),
+    industry: z.string().nullish().describe("Industry category"),
+    merchant_category_code: z.string().nullish().describe("MCC code"),
     document: documentSchema,
     phone: phoneSchema,
     address: addressSchema,
-    legal_representatives: z.array(legalRepresentativeSchema).optional().describe("Legal representatives (required for ENTITY)"),
+    legal_representatives: z.array(legalRepresentativeSchema).nullish().describe("Legal representatives (required for ENTITY)"),
     withdrawal_methods: z
       .object({
-        bank: withdrawalMethodsBankSchema.optional(),
+        bank: withdrawalMethodsBankSchema.nullish(),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("Withdrawal methods for the recipient"),
-    documentation: z.array(documentationItemSchema).optional().describe("Supporting documentation"),
-    onboardings: z.array(onboardingSchema).optional().describe("Provider onboarding configurations"),
+    documentation: z.array(documentationItemSchema).nullish().describe("Supporting documentation"),
+    onboardings: z.array(onboardingSchema).nullish().describe("Provider onboarding configurations"),
     terms_of_service: z
       .object({
         acceptance: z.boolean(),
         date: z.string(),
-        ip: z.string().optional(),
+        ip: z.string().nullish(),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("Terms of service acceptance"),
   })
   .passthrough();
@@ -111,58 +111,58 @@ const recipientCreateSchema = z
 const recipientUpdateSchema = z
   .object({
     recipientId: z.string().describe("The unique identifier of the recipient to update"),
-    merchant_recipient_id: z.string().optional().describe("The unique identifier of the recipient in the merchant system"),
-    national_entity: z.enum(["INDIVIDUAL", "ENTITY"]).optional().describe("Beneficiary's national entity type"),
-    entity_type: z.enum(["GOVERNMENTAL", "PUBLIC", "NON_PROFIT", "PRIVATE"]).optional(),
-    first_name: z.string().optional(),
-    last_name: z.string().optional(),
-    legal_name: z.string().optional(),
-    email: z.string().optional(),
-    date_of_birth: z.string().optional(),
-    country: z.string().min(2).max(2).optional(),
-    website: z.string().optional(),
-    industry: z.string().optional(),
-    merchant_category_code: z.string().optional(),
+    merchant_recipient_id: z.string().nullish().describe("The unique identifier of the recipient in the merchant system"),
+    national_entity: z.enum(["INDIVIDUAL", "ENTITY"]).nullish().describe("Beneficiary's national entity type"),
+    entity_type: z.enum(["GOVERNMENTAL", "PUBLIC", "NON_PROFIT", "PRIVATE"]).nullish(),
+    first_name: z.string().nullish(),
+    last_name: z.string().nullish(),
+    legal_name: z.string().nullish(),
+    email: z.string().nullish(),
+    date_of_birth: z.string().nullish(),
+    country: z.string().min(2).max(2).nullish(),
+    website: z.string().nullish(),
+    industry: z.string().nullish(),
+    merchant_category_code: z.string().nullish(),
     document: documentSchema,
     phone: phoneSchema,
     address: addressSchema,
-    legal_representatives: z.array(legalRepresentativeSchema).optional(),
+    legal_representatives: z.array(legalRepresentativeSchema).nullish(),
     withdrawal_methods: z
       .object({
-        bank: withdrawalMethodsBankSchema.optional(),
+        bank: withdrawalMethodsBankSchema.nullish(),
       })
       .passthrough()
-      .optional(),
-    documentation: z.array(documentationItemSchema).optional(),
-    onboardings: z.array(onboardingSchema).optional(),
+      .nullish(),
+    documentation: z.array(documentationItemSchema).nullish(),
+    onboardings: z.array(onboardingSchema).nullish(),
     terms_of_service: z
       .object({
-        acceptance: z.boolean().optional(),
-        date: z.string().optional(),
-        ip: z.string().optional(),
+        acceptance: z.boolean().nullish(),
+        date: z.string().nullish(),
+        ip: z.string().nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
   })
   .passthrough();
 
 const yunoRecipientOutputSchema = z
   .object({
-    id: z.string().optional(),
-    account_id: z.string().optional(),
-    merchant_recipient_id: z.string().optional(),
-    national_entity: z.string().optional(),
-    entity_type: z.string().optional(),
-    first_name: z.string().optional(),
-    last_name: z.string().optional(),
-    legal_name: z.string().optional(),
-    email: z.string().optional(),
-    date_of_birth: z.string().optional(),
-    country: z.string().optional(),
-    website: z.string().optional(),
-    industry: z.string().optional(),
-    merchant_category_code: z.string().optional(),
-    status: z.string().optional(),
+    id: z.string().nullish(),
+    account_id: z.string().nullish(),
+    merchant_recipient_id: z.string().nullish(),
+    national_entity: z.string().nullish(),
+    entity_type: z.string().nullish(),
+    first_name: z.string().nullish(),
+    last_name: z.string().nullish(),
+    legal_name: z.string().nullish(),
+    email: z.string().nullish(),
+    date_of_birth: z.string().nullish(),
+    country: z.string().nullish(),
+    website: z.string().nullish(),
+    industry: z.string().nullish(),
+    merchant_category_code: z.string().nullish(),
+    status: z.string().nullish(),
     document: documentSchema,
     phone: phoneSchema,
     address: addressSchema,
@@ -170,40 +170,40 @@ const yunoRecipientOutputSchema = z
       .object({
         bank: z
           .object({
-            code: z.string().optional(),
-            branch: z.string().optional(),
-            account: z.string().optional(),
-            account_type: z.string().optional(),
-            branch_digit: z.string().optional(),
-            account_digit: z.string().optional(),
-            routing: z.string().optional(),
-            country: z.string().optional(),
-            currency: z.string().optional(),
-            payout_schedule: z.string().optional(),
+            code: z.string().nullish(),
+            branch: z.string().nullish(),
+            account: z.string().nullish(),
+            account_type: z.string().nullish(),
+            branch_digit: z.string().nullish(),
+            account_digit: z.string().nullish(),
+            routing: z.string().nullish(),
+            country: z.string().nullish(),
+            currency: z.string().nullish(),
+            payout_schedule: z.string().nullish(),
           })
           .passthrough()
-          .optional(),
+          .nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     legal_representatives: z
       .array(
         z
           .object({
-            merchant_reference: z.string().optional(),
-            first_name: z.string().optional(),
-            last_name: z.string().optional(),
-            email: z.string().optional(),
-            date_of_birth: z.string().optional(),
-            country: z.string().optional(),
-            nationality: z.string().optional(),
-            title: z.string().optional(),
-            publicly_exposed_person: z.boolean().optional(),
-            ultimate_beneficial_owner: z.boolean().optional(),
+            merchant_reference: z.string().nullish(),
+            first_name: z.string().nullish(),
+            last_name: z.string().nullish(),
+            email: z.string().nullish(),
+            date_of_birth: z.string().nullish(),
+            country: z.string().nullish(),
+            nationality: z.string().nullish(),
+            title: z.string().nullish(),
+            publicly_exposed_person: z.boolean().nullish(),
+            ultimate_beneficial_owner: z.boolean().nullish(),
           })
           .passthrough(),
       )
-      .optional(),
+      .nullish(),
   })
   .passthrough();
 

--- a/src/schemas/routing.ts
+++ b/src/schemas/routing.ts
@@ -30,17 +30,17 @@ const conditionSchema = z.object({
     condition_type: z.string().describe("Type of condition"),
     values: z.array(z.any()).describe("Values for the condition"),
     conditional: z.string().describe("Conditional operator"),
-    complex_name: z.string().nullable().optional().describe("Complex name for the condition"),
-    complex_index: z.string().nullable().optional().describe("Complex index for the condition"),
-    additional_field_name: z.string().nullable().optional().describe("Additional field name"),
+    complex_name: z.string().nullish().describe("Complex name for the condition"),
+    complex_index: z.string().nullish().describe("Complex index for the condition"),
+    additional_field_name: z.string().nullish().describe("Additional field name"),
     detail: conditionDetailSchema.describe("Detailed information about the condition"),
     visible: z.boolean().describe("Whether the condition is visible"),
-    metadata_key: z.string().nullable().optional().describe("Metadata key"),
-    time_period_repeat_amount: z.number().nullable().optional().describe("Time period repeat amount"),
-    time_period_repetition_days: z.number().nullable().optional().describe("Time period repetition days"),
-    time_period_repeat_frequency: z.string().nullable().optional().describe("Time period repeat frequency"),
-    time_period_start_time: z.string().nullable().optional().describe("Time period start time"),
-    time_period_end_time: z.string().nullable().optional().describe("Time period end time"),
+    metadata_key: z.string().nullish().describe("Metadata key"),
+    time_period_repeat_amount: z.number().nullish().describe("Time period repeat amount"),
+    time_period_repetition_days: z.number().nullish().describe("Time period repetition days"),
+    time_period_repeat_frequency: z.string().nullish().describe("Time period repeat frequency"),
+    time_period_start_time: z.string().nullish().describe("Time period start time"),
+    time_period_end_time: z.string().nullish().describe("Time period end time"),
 });
 
 const routeOutputSchema = z.object({
@@ -49,13 +49,13 @@ const routeOutputSchema = z.object({
     type: z.enum(["SUCCESS", "WARNING", "ERROR"]).describe("Type of the output - must be SUCCESS, WARNING, or ERROR"),
     has_split: z.boolean().describe("Whether the output has split"),
     decline_types: z.array(z.string()).describe("Types of declines"),
-    next_route_index: z.number().nullable().optional().describe("Next route index"),
+    next_route_index: z.number().nullish().describe("Next route index"),
     next_route_indexes: z.array(z.number()).describe("Next route indexes"),
-    id: z.string().nullable().optional().describe("Output ID"),
+    id: z.string().nullish().describe("Output ID"),
 });
 
 const routeDataSchema = z.object({
-    action: z.string().nullable().optional().describe("Action for the route"),
+    action: z.string().nullish().describe("Action for the route"),
     provider_id: z.string().describe("Provider ID"),
     integration_code: z.string().describe("Integration code"),
     provider_type: z.enum(["PAYMENT", "PROCESSOR"]).describe("Type of provider - must be PAYMENT or PROCESSOR"),
@@ -84,12 +84,12 @@ const conditionSetSchema = z.object({
     updated_at: z.string().describe("Last update timestamp"),
     category: z.string().describe("Category of the condition set"),
     expired: z.boolean().describe("Whether the condition set is expired"),
-    threshold_code: z.string().nullable().optional().describe("Threshold code"),
-    monitor_active: z.boolean().nullable().optional().describe("Whether monitoring is active"),
+    threshold_code: z.string().nullish().describe("Threshold code"),
+    monitor_active: z.boolean().nullish().describe("Whether monitoring is active"),
     id: z.number().describe("Condition set ID"),
-    name: z.string().nullable().optional().describe("Name of the condition set"),
-    description: z.string().nullable().optional().describe("Description of the condition set"),
-    smart_routing_mode: z.string().nullable().optional().describe("Smart routing mode"),
+    name: z.string().nullish().describe("Name of the condition set"),
+    description: z.string().nullish().describe("Description of the condition set"),
+    smart_routing_mode: z.string().nullish().describe("Smart routing mode"),
 });
 
 const workflowSchema = z.object({
@@ -112,7 +112,7 @@ const versionSchema = z.object({
     number: z.number().describe("Version number"),
     created_at: z.string().describe("Creation timestamp"),
     updated_at: z.string().describe("Last update timestamp"),
-    published_at: z.string().nullable().optional().describe("Publication timestamp"),
+    published_at: z.string().nullish().describe("Publication timestamp"),
     name: z.string().describe("Version name"),
     publishable: z.boolean().describe("Whether the version is publishable"),
     favorite: z.boolean().describe("Whether the version is marked as favorite"),
@@ -121,30 +121,30 @@ const versionSchema = z.object({
     payment_enabled: z.boolean().describe("Whether payments are enabled"),
     fraud_enabled: z.boolean().describe("Whether fraud detection is enabled"),
     paused: z.boolean().describe("Whether the version is paused"),
-    deleted_at: z.string().nullable().optional().describe("Deletion timestamp"),
+    deleted_at: z.string().nullish().describe("Deletion timestamp"),
 });
 
 const routingIntegrationSchema = z.object({
-    integration_code: z.string().optional().describe("Integration code identifier"),
-    type: z.string().optional().describe("Type of integration"),
-    provider_id: z.string().optional().describe("Provider identifier"),
-    icon: z.string().optional().describe("Icon URL or identifier"),
-    name: z.string().optional().describe("Integration name"),
-    description: z.string().optional().describe("Integration description"),
-    active: z.boolean().optional().describe("Whether the integration is active"),
-    connection_name: z.string().optional().describe("Connection name"),
-    provider_icon: z.string().optional().describe("Provider icon URL or identifier"),
-    category: z.string().optional().describe("Integration category"),
-    created_at: z.string().optional().describe("Creation timestamp"),
-    updated_at: z.string().optional().describe("Last update timestamp"),
-    provider_name: z.string().optional().describe("Provider name"),
-    connection_state: z.string().optional().describe("Connection state"),
-    flow_type: z.string().optional().describe("Flow type"),
-    costs: z.array(z.any()).optional().describe("Associated costs"),
+    integration_code: z.string().nullish().describe("Integration code identifier"),
+    type: z.string().nullish().describe("Type of integration"),
+    provider_id: z.string().nullish().describe("Provider identifier"),
+    icon: z.string().nullish().describe("Icon URL or identifier"),
+    name: z.string().nullish().describe("Integration name"),
+    description: z.string().nullish().describe("Integration description"),
+    active: z.boolean().nullish().describe("Whether the integration is active"),
+    connection_name: z.string().nullish().describe("Connection name"),
+    provider_icon: z.string().nullish().describe("Provider icon URL or identifier"),
+    category: z.string().nullish().describe("Integration category"),
+    created_at: z.string().nullish().describe("Creation timestamp"),
+    updated_at: z.string().nullish().describe("Last update timestamp"),
+    provider_name: z.string().nullish().describe("Provider name"),
+    connection_state: z.string().nullish().describe("Connection state"),
+    flow_type: z.string().nullish().describe("Flow type"),
+    costs: z.array(z.any()).nullish().describe("Associated costs"),
 });
 
 const routingIntegrationsResponseSchema = z.object({
-    integrations: z.array(routingIntegrationSchema).optional().describe("List of integrations"),
+    integrations: z.array(routingIntegrationSchema).nullish().describe("List of integrations"),
 });
 
 const updateRouteRequestSchema = z.object({
@@ -163,199 +163,199 @@ const workflowRequestSchema = z.object({
 const yunoRoutingLoginOutputSchema = z
     .object({
         access_token: z.string(),
-        mfa_token: z.string().optional(),
-        next_step: z.string().optional(),
-        authenticator_type: z.string().optional(),
-        secret: z.string().optional(),
-        barcode_uri: z.string().optional(),
+        mfa_token: z.string().nullish(),
+        next_step: z.string().nullish(),
+        authenticator_type: z.string().nullish(),
+        secret: z.string().nullish(),
+        barcode_uri: z.string().nullish(),
     })
     .passthrough();
 
 const yunoConditionDetailOutputSchema = z
     .object({
-        name: z.string().optional(),
-        description: z.string().optional(),
-        criteria: z.string().optional(),
-        operators: z.array(z.string()).optional(),
-        payment_methods: z.array(z.string()).optional(),
-        value_source: z.string().optional(),
-        icon: z.string().optional(),
+        name: z.string().nullish(),
+        description: z.string().nullish(),
+        criteria: z.string().nullish(),
+        operators: z.array(z.string()).nullish(),
+        payment_methods: z.array(z.string()).nullish(),
+        value_source: z.string().nullish(),
+        icon: z.string().nullish(),
     })
     .passthrough();
 
 const yunoConditionOutputSchema = z
     .object({
-        condition_set_id: z.number().optional(),
-        condition_type: z.string().optional(),
-        values: z.array(z.any()).optional(),
-        conditional: z.string().optional(),
-        complex_name: z.string().nullable().optional(),
-        complex_index: z.string().nullable().optional(),
-        additional_field_name: z.string().nullable().optional(),
-        detail: yunoConditionDetailOutputSchema.optional(),
-        visible: z.boolean().optional(),
-        metadata_key: z.string().nullable().optional(),
-        time_period_repeat_amount: z.number().nullable().optional(),
-        time_period_repetition_days: z.number().nullable().optional(),
-        time_period_repeat_frequency: z.string().nullable().optional(),
-        time_period_start_time: z.string().nullable().optional(),
-        time_period_end_time: z.string().nullable().optional(),
+        condition_set_id: z.number().nullish(),
+        condition_type: z.string().nullish(),
+        values: z.array(z.any()).nullish(),
+        conditional: z.string().nullish(),
+        complex_name: z.string().nullish(),
+        complex_index: z.string().nullish(),
+        additional_field_name: z.string().nullish(),
+        detail: yunoConditionDetailOutputSchema.nullish(),
+        visible: z.boolean().nullish(),
+        metadata_key: z.string().nullish(),
+        time_period_repeat_amount: z.number().nullish(),
+        time_period_repetition_days: z.number().nullish(),
+        time_period_repeat_frequency: z.string().nullish(),
+        time_period_start_time: z.string().nullish(),
+        time_period_end_time: z.string().nullish(),
     })
     .passthrough();
 
 const yunoRouteNextIndexOutputSchema = z
     .object({
-        index: z.number().optional(),
-        percentage: z.number().optional(),
+        index: z.number().nullish(),
+        percentage: z.number().nullish(),
     })
     .passthrough();
 
 const yunoRouteOutputOutputSchema = z
     .object({
-        has_split: z.boolean().optional(),
-        output: z.string().optional(),
-        order: z.number().optional(),
-        type: z.string().optional(),
-        next_route_indexes: z.array(yunoRouteNextIndexOutputSchema).optional(),
-        next_route_index: z.number().nullable().optional(),
-        name: z.string().nullable().optional(),
-        id: z.string().nullable().optional(),
-        decline_types: z.array(z.any()).optional(),
+        has_split: z.boolean().nullish(),
+        output: z.string().nullish(),
+        order: z.number().nullish(),
+        type: z.string().nullish(),
+        next_route_indexes: z.array(yunoRouteNextIndexOutputSchema).nullish(),
+        next_route_index: z.number().nullish(),
+        name: z.string().nullish(),
+        id: z.string().nullish(),
+        decline_types: z.array(z.any()).nullish(),
     })
     .passthrough();
 
 const yunoRouteDataOutputSchema = z
     .object({
-        action: z.string().nullable().optional(),
-        integration_code: z.string().optional(),
-        provider_id: z.string().optional(),
-        provider_type: z.enum(["PAYMENT", "PROCESSOR"]).optional(),
-        provider_icon: z.string().optional(),
-        provider_name: z.string().optional(),
-        time_out: z.number().optional(),
-        monitor_message: z.boolean().optional(),
-        network_token_on: z.boolean().optional(),
-        network_token_enable: z.boolean().optional(),
-        smart_routing: z.boolean().optional(),
-        three_d_secure_exemptions: z.array(z.any()).optional(),
-        percentage: z.string().optional(),
+        action: z.string().nullish(),
+        integration_code: z.string().nullish(),
+        provider_id: z.string().nullish(),
+        provider_type: z.enum(["PAYMENT", "PROCESSOR"]).nullish(),
+        provider_icon: z.string().nullish(),
+        provider_name: z.string().nullish(),
+        time_out: z.number().nullish(),
+        monitor_message: z.boolean().nullish(),
+        network_token_on: z.boolean().nullish(),
+        network_token_enable: z.boolean().nullish(),
+        smart_routing: z.boolean().nullish(),
+        three_d_secure_exemptions: z.array(z.any()).nullish(),
+        percentage: z.string().nullish(),
     })
     .passthrough();
 
 const yunoRouteOutputSchema = z
     .object({
-        index: z.number().optional(),
-        outputs: z.array(yunoRouteOutputOutputSchema).optional(),
-        data: yunoRouteDataOutputSchema.optional(),
-        type: z.enum(["PROVIDER", "CONDITION"]).optional(),
-        updated_at: z.string().optional(),
-        repair: z.boolean().optional(),
-        paused: z.boolean().optional(),
-        alerted: z.boolean().optional(),
+        index: z.number().nullish(),
+        outputs: z.array(yunoRouteOutputOutputSchema).nullish(),
+        data: yunoRouteDataOutputSchema.nullish(),
+        type: z.enum(["PROVIDER", "CONDITION"]).nullish(),
+        updated_at: z.string().nullish(),
+        repair: z.boolean().nullish(),
+        paused: z.boolean().nullish(),
+        alerted: z.boolean().nullish(),
     })
     .passthrough();
 
 const yunoConditionSetStartOutputSchema = z
     .object({
-        index: z.number().optional(),
-        percentage: z.number().optional(),
+        index: z.number().nullish(),
+        percentage: z.number().nullish(),
     })
     .passthrough();
 
 const yunoConditionSetOutputSchema = z
     .object({
-        editable: z.boolean().optional(),
-        sort_number: z.number().optional(),
-        conditions: z.array(yunoConditionOutputSchema).optional(),
-        routes: z.array(yunoRouteOutputSchema).optional(),
-        start: z.array(yunoConditionSetStartOutputSchema).optional(),
-        updated_at: z.string().optional(),
-        category: z.string().optional(),
-        expired: z.boolean().optional(),
-        threshold_code: z.string().nullable().optional(),
-        monitor_active: z.boolean().nullable().optional(),
-        id: z.number().optional(),
-        name: z.string().nullable().optional(),
-        description: z.string().nullable().optional(),
-        smart_routing_mode: z.string().nullable().optional(),
+        editable: z.boolean().nullish(),
+        sort_number: z.number().nullish(),
+        conditions: z.array(yunoConditionOutputSchema).nullish(),
+        routes: z.array(yunoRouteOutputSchema).nullish(),
+        start: z.array(yunoConditionSetStartOutputSchema).nullish(),
+        updated_at: z.string().nullish(),
+        category: z.string().nullish(),
+        expired: z.boolean().nullish(),
+        threshold_code: z.string().nullish(),
+        monitor_active: z.boolean().nullish(),
+        id: z.number().nullish(),
+        name: z.string().nullish(),
+        description: z.string().nullish(),
+        smart_routing_mode: z.string().nullish(),
     })
     .passthrough();
 
 const yunoWorkflowOutputSchema = z
     .object({
-        id: z.number().optional(),
-        code: z.string().optional(),
-        name: z.string().optional(),
-        status: z.string().optional(),
-        account_code: z.string().optional(),
-        created_at: z.string().optional(),
-        updated_at: z.string().optional(),
-        payment_method_type: z.string().optional(),
-        is_active: z.boolean().optional(),
+        id: z.number().nullish(),
+        code: z.string().nullish(),
+        name: z.string().nullish(),
+        status: z.string().nullish(),
+        account_code: z.string().nullish(),
+        created_at: z.string().nullish(),
+        updated_at: z.string().nullish(),
+        payment_method_type: z.string().nullish(),
+        is_active: z.boolean().nullish(),
     })
     .passthrough();
 
 const yunoWorkflowVersionOutputSchema = z
     .object({
-        id: z.number().optional(),
-        workflow_id: z.number().optional(),
-        code: z.string().optional(),
-        status: z.string().optional(),
-        number: z.number().optional(),
-        created_at: z.string().optional(),
-        updated_at: z.string().optional(),
-        published_at: z.string().nullable().optional(),
-        name: z.string().optional(),
-        publishable: z.boolean().optional(),
-        favorite: z.boolean().optional(),
-        repair: z.boolean().optional(),
-        updated_by: z.string().optional(),
-        payment_enabled: z.boolean().optional(),
-        fraud_enabled: z.boolean().optional(),
-        paused: z.boolean().optional(),
-        deleted_at: z.string().nullable().optional(),
+        id: z.number().nullish(),
+        workflow_id: z.number().nullish(),
+        code: z.string().nullish(),
+        status: z.string().nullish(),
+        number: z.number().nullish(),
+        created_at: z.string().nullish(),
+        updated_at: z.string().nullish(),
+        published_at: z.string().nullish(),
+        name: z.string().nullish(),
+        publishable: z.boolean().nullish(),
+        favorite: z.boolean().nullish(),
+        repair: z.boolean().nullish(),
+        updated_by: z.string().nullish(),
+        payment_enabled: z.boolean().nullish(),
+        fraud_enabled: z.boolean().nullish(),
+        paused: z.boolean().nullish(),
+        deleted_at: z.string().nullish(),
     })
     .passthrough();
 
 const yunoRoutingWorkflowOutputSchema = z
     .object({
-        workflow: yunoWorkflowOutputSchema.optional(),
-        version: yunoWorkflowVersionOutputSchema.optional(),
-        condition_sets: z.array(yunoConditionSetOutputSchema).optional(),
+        workflow: yunoWorkflowOutputSchema.nullish(),
+        version: yunoWorkflowVersionOutputSchema.nullish(),
+        condition_sets: z.array(yunoConditionSetOutputSchema).nullish(),
     })
     .passthrough();
 
 const yunoRoutingIntegrationOutputSchema = z
     .object({
-        integration_code: z.string().optional(),
-        type: z.string().optional(),
-        provider_id: z.string().optional(),
-        icon: z.string().optional(),
-        name: z.string().optional(),
-        description: z.string().optional(),
-        active: z.boolean().optional(),
-        connection_name: z.string().optional(),
-        provider_icon: z.string().optional(),
-        category: z.string().optional(),
-        created_at: z.string().optional(),
-        updated_at: z.string().optional(),
-        provider_name: z.string().optional(),
-        connection_state: z.string().optional(),
-        flow_type: z.string().optional(),
-        costs: z.array(z.any()).optional(),
+        integration_code: z.string().nullish(),
+        type: z.string().nullish(),
+        provider_id: z.string().nullish(),
+        icon: z.string().nullish(),
+        name: z.string().nullish(),
+        description: z.string().nullish(),
+        active: z.boolean().nullish(),
+        connection_name: z.string().nullish(),
+        provider_icon: z.string().nullish(),
+        category: z.string().nullish(),
+        created_at: z.string().nullish(),
+        updated_at: z.string().nullish(),
+        provider_name: z.string().nullish(),
+        connection_state: z.string().nullish(),
+        flow_type: z.string().nullish(),
+        costs: z.array(z.any()).nullish(),
     })
     .passthrough();
 
 const yunoRoutingIntegrationsOutputSchema = z
     .object({
-        integrations: z.array(yunoRoutingIntegrationOutputSchema).optional(),
+        integrations: z.array(yunoRoutingIntegrationOutputSchema).nullish(),
     })
     .passthrough();
 
 const yunoRoutingLogoutOutputSchema = z
     .object({
-        success: z.boolean().optional(),
-        message: z.string().optional(),
+        success: z.boolean().nullish(),
+        message: z.string().nullish(),
     })
     .passthrough();
 

--- a/src/schemas/shared.ts
+++ b/src/schemas/shared.ts
@@ -3,19 +3,19 @@ import z from "zod";
 const addressSchema = z
   .object({
     address_line_1: z.string(),
-    address_line_2: z.string().optional(),
-    building_number_1: z.string().optional(),
-    building_number_2: z.string().optional(),
-    country: z.string().min(2).max(2).optional().describe("Country (ISO 3166-1)"),
-    state: z.string().optional(),
+    address_line_2: z.string().nullish(),
+    building_number_1: z.string().nullish(),
+    building_number_2: z.string().nullish(),
+    country: z.string().min(2).max(2).nullish().describe("Country (ISO 3166-1)"),
+    state: z.string().nullish(),
     city: z.string(),
-    zip_code: z.string().optional(),
-    neighborhood: z.string().optional(),
+    zip_code: z.string().nullish(),
+    neighborhood: z.string().nullish(),
   })
   .passthrough()
-  .optional();
+  .nullish();
 
-const metadataSchema = z.array(z.object({ key: z.string(), value: z.string() })).optional();
+const metadataSchema = z.array(z.object({ key: z.string(), value: z.string() })).nullish();
 
 const phoneSchema = z
   .object({
@@ -23,7 +23,7 @@ const phoneSchema = z
     country_code: z.string(),
   })
   .passthrough()
-  .optional();
+  .nullish();
 
 const documentSchema = z
   .object({
@@ -31,17 +31,17 @@ const documentSchema = z
     document_number: z.string(),
   })
   .passthrough()
-  .optional();
+  .nullish();
 
 const cardDataSchema = z
   .object({
     number: z.string().min(8).max(19),
     expiration_month: z.number().min(1).max(12),
     expiration_year: z.number().min(1).max(9999),
-    security_code: z.string().min(3).max(4).optional(),
-    holder_name: z.string().min(3).max(26).optional(),
-    type: z.string().optional().nullable(),
-    brand: z.string().optional(),
+    security_code: z.string().min(3).max(4).nullish(),
+    holder_name: z.string().min(3).max(26).nullish(),
+    type: z.string().nullish(),
+    brand: z.string().nullish(),
   })
   .passthrough();
 

--- a/src/schemas/subscriptions.ts
+++ b/src/schemas/subscriptions.ts
@@ -3,41 +3,41 @@ import { amountSchema, cardDataSchema, metadataSchema } from "./shared";
 
 const yunoSubscriptionOutputSchema = z
   .object({
-    account_id: z.string().optional(),
-    name: z.string().optional(),
-    description: z.string().optional(),
-    merchant_reference: z.string().optional(),
+    account_id: z.string().nullish(),
+    name: z.string().nullish(),
+    description: z.string().nullish(),
+    merchant_reference: z.string().nullish(),
     amount: z
       .object({
         currency: z.string(),
         value: z.number(),
       })
       .passthrough()
-      .optional(),
-    status: z.string().optional(),
-    additional_data: z.any().optional(),
+      .nullish(),
+    status: z.string().nullish(),
+    additional_data: z.any().nullish(),
     frequency: z
       .object({
         type: z.enum(["DAY", "WEEK", "MONTH"]),
-        value: z.number().optional(),
+        value: z.number().nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     billing_cycles: z
       .object({
         total: z.number(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     payment_method: z
       .object({
-        type: z.enum(["CARD"]).optional(),
-        vaulted_token: z.string().optional(),
+        type: z.enum(["CARD"]).nullish(),
+        vaulted_token: z.string().nullish(),
         card: z
           .object({
-            installments: z.number().optional(),
-            network_transaction_id: z.string().optional(),
-            verify: z.boolean().optional(),
+            installments: z.number().nullish(),
+            network_transaction_id: z.string().nullish(),
+            verify: z.boolean().nullish(),
             card_data: z
               .object({
                 number: z.string(),
@@ -47,122 +47,121 @@ const yunoSubscriptionOutputSchema = z
                 holder_name: z.string(),
               })
               .passthrough()
-              .optional(),
+              .nullish(),
           })
           .passthrough()
-          .optional(),
+          .nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     trial_period: z
       .object({
-        billing_cycles: z.number().optional(),
-        amount: amountSchema.optional(),
+        billing_cycles: z.number().nullish(),
+        amount: amountSchema.nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     availability: z
       .object({
-        start_at: z.string().optional(),
-        finish_at: z.string().optional(),
+        start_at: z.string().nullish(),
+        finish_at: z.string().nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     metadata: metadataSchema,
   })
   .passthrough();
 
 const subscriptionCreateSchema = z
   .object({
-    account_id: z.string().optional().describe("Account ID for the subscription"),
+    account_id: z.string().nullish().describe("Account ID for the subscription"),
     name: z.string().min(3).max(255).describe("The name of the subscription"),
-    description: z.string().min(3).max(255).optional().describe("The description of the subscription"),
-    merchant_reference: z.string().min(3).max(255).optional().describe("Merchant reference for the subscription"),
+    description: z.string().min(3).max(255).nullish().describe("The description of the subscription"),
+    merchant_reference: z.string().min(3).max(255).nullish().describe("Merchant reference for the subscription"),
     country: z.string().min(2).max(2).describe("Country (ISO 3166-1)"),
     amount: amountSchema,
-    additional_data: z.any().optional().describe("Additional data for the subscription"),
+    additional_data: z.any().nullish().describe("Additional data for the subscription"),
     frequency: z
       .object({
         type: z.enum(["DAY", "WEEK", "MONTH"]),
-        value: z.number().optional(),
+        value: z.number().nullish(),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("Frequency of the subscription"),
     billing_cycles: z
       .object({
         total: z.number(),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("Total billing cycles"),
     customer_payer: z
       .object({
         id: z.string().describe("The unique identifier of the customer"),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     payment_method: z
       .object({
         type: z.enum(["CARD"]).describe("Payment method type"),
-        vaulted_token: z.string().optional().describe("Vaulted token for enrolled card"),
+        vaulted_token: z.string().describe("Vaulted token for enrolled card"),
         card: z
           .object({
-            installments: z.number().int().min(1).max(50).optional().describe("Number of installments"),
-            network_transaction_id: z.string().optional().describe("Visa/Mastercard ID from initial payment"),
+            installments: z.number().int().min(1).max(50).nullish().describe("Number of installments"),
+            network_transaction_id: z.string().nullish().describe("Visa/Mastercard ID from initial payment"),
           })
           .passthrough()
-          .optional(),
+          .nullish(),
       })
       .passthrough()
-      .optional()
       .describe("Payment method for the subscription"),
     trial_period: z
       .object({
-        billing_cycles: z.number().int().min(1).optional().describe("Trial duration in billing cycles"),
-        amount: amountSchema.optional().describe("Discounted amount during trial"),
+        billing_cycles: z.number().int().min(1).nullish().describe("Trial duration in billing cycles"),
+        amount: amountSchema.nullish().describe("Discounted amount during trial"),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("Trial period for the subscription"),
     availability: z
       .object({
-        start_at: z.string().optional().describe("Start date (ISO 8601)"),
-        finish_at: z.string().optional().describe("End date (ISO 8601)"),
+        start_at: z.string().nullish().describe("Start date (ISO 8601)"),
+        finish_at: z.string().nullish().describe("End date (ISO 8601)"),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("Availability for the subscription"),
     metadata: metadataSchema,
     retries: z
       .object({
-        retry_on_decline: z.boolean().optional().describe("Enable retry logic"),
-        amount: z.number().int().max(6).optional().describe("Retry count (max 6)"),
-        strategy: z.string().optional().describe("Schedule strategy"),
+        retry_on_decline: z.boolean().nullish().describe("Enable retry logic"),
+        amount: z.number().int().max(6).nullish().describe("Retry count (max 6)"),
+        strategy: z.string().nullish().describe("Schedule strategy"),
         schedule: z
           .array(
             z
               .object({
-                attempt: z.number().optional(),
-                delay_seconds: z.number().optional(),
+                attempt: z.number().nullish(),
+                delay_seconds: z.number().nullish(),
               })
               .passthrough(),
           )
-          .optional()
+          .nullish()
           .describe("Per-attempt schedule"),
-        stop_on_hard_decline: z.boolean().optional().describe("Halt retries after hard decline"),
+        stop_on_hard_decline: z.boolean().nullish().describe("Halt retries after hard decline"),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("Retries for the subscription"),
-    initial_payment_validation: z.boolean().optional().describe("Initial payment validation flag"),
+    initial_payment_validation: z.boolean().nullish().describe("Initial payment validation flag"),
     billing_date: z
       .object({
-        type: z.enum(["PREPAID", "POSTDATE", "DAY"]).optional().describe("Billing date type"),
-        day: z.number().int().min(1).max(31).optional().describe("Day of month for DAY type"),
+        type: z.enum(["PREPAID", "POSTDATE", "DAY"]).nullish().describe("Billing date type"),
+        day: z.number().int().min(1).max(31).nullish().describe("Day of month for DAY type"),
       })
       .passthrough()
-      .optional()
+      .nullish()
       .describe("Billing date for the subscription"),
   })
   .passthrough();
@@ -170,66 +169,66 @@ const subscriptionCreateSchema = z
 const subscriptionUpdateSchema = z
   .object({
     subscriptionId: z.string().describe("The unique identifier of the subscription to update"),
-    account_id: z.string().optional().describe("Account ID"),
-    name: z.string().optional(),
-    description: z.string().optional(),
-    merchant_reference: z.string().optional(),
-    country: z.string().optional(),
+    account_id: z.string().nullish().describe("Account ID"),
+    name: z.string().nullish(),
+    description: z.string().nullish(),
+    merchant_reference: z.string().nullish(),
+    country: z.string().nullish(),
     amount: z
       .object({
         currency: z.string(),
         value: z.number(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     frequency: z
       .object({
         type: z.enum(["DAY", "WEEK", "MONTH"]),
-        value: z.number().optional(),
-        monthly_billing_day: z.number().int().min(1).max(31).optional().describe("Monthly billing day"),
+        value: z.number().nullish(),
+        monthly_billing_day: z.number().int().min(1).max(31).nullish().describe("Monthly billing day"),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     billing_cycles: z
       .object({
         total: z.number(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     customer_payer: z
       .object({
         id: z.string(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     payment_method: z
       .object({
-        type: z.enum(["CARD"]).optional(),
-        vaulted_token: z.string().optional(),
+        type: z.enum(["CARD"]).nullish(),
+        vaulted_token: z.string().nullish(),
         card: z
           .object({
-            verify: z.boolean().optional(),
-            card_data: cardDataSchema.optional(),
+            verify: z.boolean().nullish(),
+            card_data: cardDataSchema.nullish(),
           })
           .passthrough()
-          .optional(),
+          .nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     availability: z
       .object({
-        start_at: z.string().optional(),
-        finish_at: z.string().optional(),
+        start_at: z.string().nullish(),
+        finish_at: z.string().nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     retries: z
       .object({
-        retry_on_decline: z.boolean().optional(),
-        amount: z.number().optional(),
+        retry_on_decline: z.boolean().nullish(),
+        amount: z.number().nullish(),
       })
       .passthrough()
-      .optional(),
+      .nullish(),
     metadata: metadataSchema,
   })
   .passthrough();

--- a/src/tools/customers/index.ts
+++ b/src/tools/customers/index.ts
@@ -103,7 +103,7 @@ export const customerUpdateTool = {
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
     async ({ customerId, ...updateFields }: CustomerUpdateSchema): Promise<Output<TType, YunoCustomer>> => {
-      const { body: customer, status, headers } = await yunoClient.customers.update(customerId, updateFields);
+      const { body: customer, status, headers } = await yunoClient.customers.update(customerId, updateFields as Partial<YunoCustomer>);
 
       if (type === "text") {
         return {

--- a/src/tools/installmentPlans/index.ts
+++ b/src/tools/installmentPlans/index.ts
@@ -3,6 +3,7 @@ import {
   installmentPlanCreateSchema,
   installmentPlanUpdateSchema,
   yunoInstallmentPlanOutputSchema,
+  yunoInstallmentPlanListOutputSchema,
 } from "../../schemas";
 import type { HandlerContext, Output, Tool } from "../../types";
 import type { InstallmentPlanCreateSchema, InstallmentPlanUpdateSchema, YunoInstallmentPlan } from "./types";
@@ -20,7 +21,7 @@ export const installmentPlanCreateTool = {
         ...data,
         account_id: data.account_id || [yunoClient.accountCode],
       };
-      const { body: plan, status, headers } = await yunoClient.installmentPlans.create(planWithAccount);
+      const { body: plan, status, headers } = await yunoClient.installmentPlans.create(planWithAccount as YunoInstallmentPlan);
 
       if (type === "text") {
         return {
@@ -78,10 +79,10 @@ export const installmentPlanRetrieveAllTool = {
   schema: z.object({
     accountId: z.string().describe("The account_id to retrieve all installment plans for"),
   }),
-  outputSchema: yunoInstallmentPlanOutputSchema,
+  outputSchema: yunoInstallmentPlanListOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
-    async ({ accountId }: { accountId: string }): Promise<Output<TType, YunoInstallmentPlan>> => {
+    async ({ accountId }: { accountId: string }): Promise<Output<TType, { items: YunoInstallmentPlan[] }>> => {
       const { body: plans, status, headers } = await yunoClient.installmentPlans.retrieveAll(accountId);
 
       if (type === "text") {
@@ -90,15 +91,15 @@ export const installmentPlanRetrieveAllTool = {
             { type: "text" as const, text: JSON.stringify(plans, null, 4) },
             { type: "text" as const, text: `Response Headers (HTTP ${status}):\n${JSON.stringify(headers, null, 4)}` },
           ],
-        } as Output<TType, YunoInstallmentPlan>;
+        } as Output<TType, { items: YunoInstallmentPlan[] }>;
       }
 
       return {
         content: [
-          { type: "object" as const, object: plans },
+          { type: "object" as const, object: { items: plans ?? [] } },
           { type: "text" as const, text: `Response Headers (HTTP ${status}):\n${JSON.stringify(headers, null, 4)}` },
         ],
-      } as Output<TType, YunoInstallmentPlan>;
+      } as Output<TType, { items: YunoInstallmentPlan[] }>;
     },
 } as const satisfies Tool;
 

--- a/src/tools/paymentLinks/index.ts
+++ b/src/tools/paymentLinks/index.ts
@@ -16,7 +16,7 @@ export const paymentLinkCreateTool = {
         ...data,
         account_id: data.account_id || yunoClient.accountCode,
       };
-      const { body: paymentLink, status, headers } = await yunoClient.paymentLinks.create(paymentLinkWithAccount);
+      const { body: paymentLink, status, headers } = await yunoClient.paymentLinks.create(paymentLinkWithAccount as YunoPaymentLink);
 
       if (type === "text") {
         return {

--- a/src/tools/paymentMethods/index.ts
+++ b/src/tools/paymentMethods/index.ts
@@ -2,6 +2,7 @@ import z from "zod";
 import {
   paymentMethodEnrollSchema,
   yunoPaymentMethodOutputSchema,
+  yunoPaymentMethodListOutputSchema,
 } from "../../schemas";
 import { randomUUID } from "node:crypto";
 import type { YunoClient } from "../../client";
@@ -93,10 +94,10 @@ export const paymentMethodRetrieveEnrolledTool = {
   schema: z.object({
     customer_id: z.string().min(36).max(64).describe("The unique identifier of the customer (MIN 36, MAX 64)."),
   }),
-  outputSchema: yunoPaymentMethodOutputSchema,
+  outputSchema: yunoPaymentMethodListOutputSchema,
   handler:
     <TType extends "object" | "text">({ yunoClient, type }: HandlerContext<TType>) =>
-    async ({ customer_id }: { customer_id: string }): Promise<Output<TType, YunoPaymentMethod>> => {
+    async ({ customer_id }: { customer_id: string }): Promise<Output<TType, { payment_methods?: YunoPaymentMethod[] | null }>> => {
       const { body, status, headers } = await yunoClient.paymentMethods.retrieveEnrolled(customer_id);
 
       if (type === "text") {
@@ -105,7 +106,7 @@ export const paymentMethodRetrieveEnrolledTool = {
             { type: "text" as const, text: JSON.stringify(body, null, 4) },
             { type: "text" as const, text: `Response Headers (HTTP ${status}):\n${JSON.stringify(headers, null, 4)}` },
           ],
-        } as Output<TType, YunoPaymentMethod>;
+        } as Output<TType, { payment_methods?: YunoPaymentMethod[] | null }>;
       }
 
       return {
@@ -113,7 +114,7 @@ export const paymentMethodRetrieveEnrolledTool = {
           { type: "object" as const, object: body },
           { type: "text" as const, text: `Response Headers (HTTP ${status}):\n${JSON.stringify(headers, null, 4)}` },
         ],
-      } as Output<TType, YunoPaymentMethod>;
+      } as Output<TType, { payment_methods?: YunoPaymentMethod[] | null }>;
     },
 } as const satisfies Tool;
 

--- a/src/tools/payments/index.ts
+++ b/src/tools/payments/index.ts
@@ -139,7 +139,7 @@ export const paymentRetrieveByMerchantOrderIdTool = {
         content: [
           {
             type: "object" as const,
-            object: { items: payments },
+            object: { items: payments ?? [] },
           },
           {
             type: "text" as const,

--- a/src/tools/subscriptions/index.ts
+++ b/src/tools/subscriptions/index.ts
@@ -17,7 +17,7 @@ export const subscriptionCreateTool = {
         ...data,
         account_id: data.account_id || yunoClient.accountCode,
       };
-      const { body: subscription, status, headers } = await yunoClient.subscriptions.create(subscriptionWithAccount);
+      const { body: subscription, status, headers } = await yunoClient.subscriptions.create(subscriptionWithAccount as YunoSubscription);
 
       if (type === "text") {
         return {

--- a/tests/installmentPlans.test.ts
+++ b/tests/installmentPlans.test.ts
@@ -39,6 +39,8 @@ describe("installmentPlanCreateTool", () => {
       name: "Plan 1",
       merchant_reference: "ref_1",
       installments_plan: [{ installment: 3, rate: 1.5 }],
+      country_code: "US",
+      amount: { currency: "USD" },
     };
     expect(() => installmentPlanCreateSchema.parse(minimal)).not.toThrow();
   });

--- a/tests/paymentLinks.test.ts
+++ b/tests/paymentLinks.test.ts
@@ -27,6 +27,7 @@ describe("paymentLinkCreateTool", () => {
 
   it("should validate a correct minimal payload (only required fields)", () => {
     const minimal = {
+      description: "Test link",
       country: "US",
       amount: { currency: "USD", value: 100 },
       payment_method_types: ["card"],

--- a/tests/subscriptions.test.ts
+++ b/tests/subscriptions.test.ts
@@ -35,6 +35,7 @@ describe("subscriptionCreateTool", () => {
       name: "Test Sub",
       country: "US",
       amount: { currency: "USD", value: 100 },
+      payment_method: { type: "CARD", vaulted_token: "vt_123" },
     };
     expect(() => subscriptionCreateSchema.parse(minimal)).not.toThrow();
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Zod validation semantics (many fields now accept `null`) and adjusts tool output shapes for list endpoints, which can affect downstream consumers and structured output parsing.
> 
> **Overview**
> Bumps package/server version to `0.4.1` and updates MCP tool registration to pass the full `outputSchema` (not just `.shape`), mark upstream HTTP >=400 responses as `isError`, and treat thrown errors as `isError`.
> 
> Aligns API typing and tool outputs with upstream responses: `paymentMethods.retrieveEnrolled` now returns `{ payment_methods }`, installment plan retrieval returns arrays and wraps list tools in `{ items: [...] }` (defaulting to empty arrays when null/undefined).
> 
> Broadly relaxes and standardizes Zod schemas across resources by switching many `optional()/nullable()` fields to `nullish()` (accepting `null`), adds list output schemas for payment methods/installment plans, and adds a payment create validation requiring `checkout.session` when `workflow` is `SDK_CHECKOUT` (plus a few minimal-payload test updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4688aa6a88ea13c34eb03cd1636dcf76d59be142. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->