### PR TITLE
fix(CORECM-17357): set readOnlyHint/destructiveHint/openWorldHint explicitly on every tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yuno/yuno-mcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yuno/yuno-mcp",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",
         "zod": "^4.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuno/yuno-mcp",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Yuno MCP server: create and manage payments, subscriptions, customers, payment methods, checkouts, recipients, installment plans, payment links, and routing on the Yuno payments platform.",
   "type": "module",
   "exports": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ function createYunoMCPServer(yunoClient: YunoClient, options: CreateOptions = {}
     {
       name: "yuno-mcp",
       title: "Yuno",
-      version: "0.4.1",
+      version: "0.4.2",
       description:
         "Yuno MCP server: create and manage payments, subscriptions, customers, payment methods, checkouts, recipients, installment plans, payment links, and routing on the Yuno payments platform.",
       websiteUrl: "https://docs.y.uno/mcp",

--- a/src/tools/checkouts/index.ts
+++ b/src/tools/checkouts/index.ts
@@ -12,7 +12,7 @@ import type { YunoCheckoutPaymentMethodsResponse, YunoCheckoutSession, YunoOttCr
 export const checkoutSessionCreateTool = {
   method: "checkoutSessionCreate",
   description: "Create a new checkout session in Yuno.",
-  annotations: { openWorldHint: true, title: "Create Checkout Session", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Create Checkout Session", destructiveHint: false, idempotentHint: false },
   schema: checkoutSessionCreateSchema,
   outputSchema: yunoCheckoutSessionOutputSchema,
   handler:
@@ -45,7 +45,7 @@ export const checkoutSessionCreateTool = {
 export const checkoutSessionRetrievePaymentMethodsTool = {
   method: "checkoutSessionRetrievePaymentMethods",
   description: "Retrieve payment methods for a checkout session in Yuno.",
-  annotations: { openWorldHint: true, title: "Retrieve Checkout Payment Methods", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Checkout Payment Methods", readOnlyHint: true, destructiveHint: false },
   schema: z.object({
     sessionId: z.string().describe("The unique identifier of the checkout session"),
   }),
@@ -76,7 +76,7 @@ export const checkoutSessionRetrievePaymentMethodsTool = {
 export const checkoutSessionCreateOttTool = {
   method: "checkoutSessionCreateOtt",
   description: "Generate a One Time Token (OTT) for a checkout session in Yuno.",
-  annotations: { openWorldHint: true, title: "Create Checkout One-Time Token", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Create Checkout One-Time Token", destructiveHint: false, idempotentHint: false },
   schema: ottCreateSchema,
   outputSchema: yunoOttOutputSchema,
   handler:

--- a/src/tools/customers/index.ts
+++ b/src/tools/customers/index.ts
@@ -6,7 +6,7 @@ import type { CustomerUpdateSchema, YunoCustomer } from "./types";
 export const customerCreateTool = {
   method: "customerCreate",
   description: "Create a new customer in Yuno.",
-  annotations: { openWorldHint: true, title: "Create Customer", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Create Customer", destructiveHint: false, idempotentHint: false },
   schema: customerCreateSchema,
   outputSchema: yunoCustomerOutputSchema,
   handler:
@@ -35,7 +35,7 @@ export const customerCreateTool = {
 export const customerRetrieveTool = {
   method: "customerRetrieve",
   description: "Retrieve a customer by ID.",
-  annotations: { openWorldHint: true, title: "Retrieve Customer", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Customer", readOnlyHint: true, destructiveHint: false },
   schema: z.object({
     customerId: z.string().min(36).max(64).describe("The unique identifier of the customer to retrieve (MIN 36, MAX 64 characters)"),
   }),
@@ -66,7 +66,7 @@ export const customerRetrieveTool = {
 export const customerRetrieveByExternalIdTool = {
   method: "customerRetrieveByExternalId",
   description: "Retrieve a customer by external merchant_customer_id.",
-  annotations: { openWorldHint: true, title: "Retrieve Customer by External ID", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Customer by External ID", readOnlyHint: true, destructiveHint: false },
   schema: z.object({
     merchant_customer_id: z.string().describe("The external merchant_customer_id to retrieve the customer"),
   }),
@@ -97,7 +97,7 @@ export const customerRetrieveByExternalIdTool = {
 export const customerUpdateTool = {
   method: "customerUpdate",
   description: "Update a customer by ID.",
-  annotations: { openWorldHint: true, title: "Update Customer", destructiveHint: false, idempotentHint: true },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Update Customer", destructiveHint: false, idempotentHint: true },
   schema: customerUpdateSchema,
   outputSchema: yunoCustomerOutputSchema,
   handler:

--- a/src/tools/documentation/index.ts
+++ b/src/tools/documentation/index.ts
@@ -25,7 +25,7 @@ const documentationIndexTool = {
   method: "documentationIndex",
   description:
     "Retrieve the Yuno documentation index (llms.txt) listing all available API references, SDK guides, and integration tutorials with their URLs.",
-  annotations: { openWorldHint: true, title: "Yuno Documentation Index", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Yuno Documentation Index", readOnlyHint: true, destructiveHint: false },
   schema: documentationIndexSchema,
   outputSchema: documentationIndexOutputSchema,
   handler:
@@ -63,7 +63,7 @@ const documentationReadTool = {
   method: "documentationRead",
   description:
     "Read a specific Yuno documentation page by URL. Use the documentation index tool first to discover available pages and their URLs.",
-  annotations: { openWorldHint: true, title: "Read Yuno Documentation", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Read Yuno Documentation", readOnlyHint: true, destructiveHint: false },
   schema: documentationReadSchema,
   outputSchema: documentationReadOutputSchema,
   handler:

--- a/src/tools/installmentPlans/index.ts
+++ b/src/tools/installmentPlans/index.ts
@@ -11,7 +11,7 @@ import type { InstallmentPlanCreateSchema, InstallmentPlanUpdateSchema, YunoInst
 export const installmentPlanCreateTool = {
   method: "installmentPlanCreate",
   description: "Create an installment plan in Yuno.",
-  annotations: { openWorldHint: true, title: "Create Installment Plan", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Create Installment Plan", destructiveHint: false, idempotentHint: false },
   schema: installmentPlanCreateSchema,
   outputSchema: yunoInstallmentPlanOutputSchema,
   handler:
@@ -44,7 +44,7 @@ export const installmentPlanCreateTool = {
 export const installmentPlanRetrieveTool = {
   method: "installmentPlanRetrieve",
   description: "Retrieve an installment plan in Yuno by its ID.",
-  annotations: { openWorldHint: true, title: "Retrieve Installment Plan", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Installment Plan", readOnlyHint: true, destructiveHint: false },
   schema: z.object({
     planId: z.string().describe("The unique identifier of the installment plan to retrieve"),
   }),
@@ -75,7 +75,7 @@ export const installmentPlanRetrieveTool = {
 export const installmentPlanRetrieveAllTool = {
   method: "installmentPlanRetrieveAll",
   description: "Retrieve all installment plans in Yuno for an account.",
-  annotations: { openWorldHint: true, title: "Retrieve All Installment Plans", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve All Installment Plans", readOnlyHint: true, destructiveHint: false },
   schema: z.object({
     accountId: z.string().describe("The account_id to retrieve all installment plans for"),
   }),
@@ -106,7 +106,7 @@ export const installmentPlanRetrieveAllTool = {
 export const installmentPlanUpdateTool = {
   method: "installmentPlanUpdate",
   description: "Update an installment plan in Yuno by its ID.",
-  annotations: { openWorldHint: true, title: "Update Installment Plan", destructiveHint: false, idempotentHint: true },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Update Installment Plan", destructiveHint: false, idempotentHint: true },
   schema: installmentPlanUpdateSchema,
   outputSchema: yunoInstallmentPlanOutputSchema,
   handler:
@@ -135,7 +135,7 @@ export const installmentPlanUpdateTool = {
 export const installmentPlanDeleteTool = {
   method: "installmentPlanDelete",
   description: "Delete an installment plan in Yuno by its ID.",
-  annotations: { openWorldHint: true, title: "Delete Installment Plan", destructiveHint: true, idempotentHint: true },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Delete Installment Plan", destructiveHint: true, idempotentHint: true },
   schema: z.object({
     planId: z.string().describe("The unique identifier of the installment plan to delete"),
   }),

--- a/src/tools/paymentLinks/index.ts
+++ b/src/tools/paymentLinks/index.ts
@@ -6,7 +6,7 @@ import type { PaymentLinkCancelSchema, PaymentLinkCreateSchema, YunoPaymentLink 
 export const paymentLinkCreateTool = {
   method: "paymentLinkCreate",
   description: "Create a payment link in Yuno.",
-  annotations: { openWorldHint: true, title: "Create Payment Link", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Create Payment Link", destructiveHint: false, idempotentHint: false },
   schema: paymentLinkCreateSchema,
   outputSchema: yunoPaymentLinkOutputSchema,
   handler:
@@ -39,7 +39,7 @@ export const paymentLinkCreateTool = {
 export const paymentLinkRetrieveTool = {
   method: "paymentLinkRetrieve",
   description: "Retrieve a payment link in Yuno by its ID.",
-  annotations: { openWorldHint: true, title: "Retrieve Payment Link", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Payment Link", readOnlyHint: true, destructiveHint: false },
   schema: z.object({
     paymentLinkId: z.string().describe("The unique identifier of the payment link to retrieve"),
   }),
@@ -70,7 +70,7 @@ export const paymentLinkRetrieveTool = {
 export const paymentLinkCancelTool = {
   method: "paymentLinkCancel",
   description: "Cancel a payment link in Yuno by its ID.",
-  annotations: { openWorldHint: true, title: "Cancel Payment Link", destructiveHint: true, idempotentHint: true },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Cancel Payment Link", destructiveHint: true, idempotentHint: true },
   schema: paymentLinkCancelSchema,
   outputSchema: yunoPaymentLinkOutputSchema,
   handler:

--- a/src/tools/paymentMethods/index.ts
+++ b/src/tools/paymentMethods/index.ts
@@ -12,7 +12,7 @@ import type { PaymentMethodEnrollSchema, YunoPaymentMethod } from "./types";
 export const paymentMethodEnrollTool = {
   method: "paymentMethodEnroll",
   description: `Enroll or create payment method.`,
-  annotations: { openWorldHint: true, title: "Enroll Payment Method", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Enroll Payment Method", destructiveHint: false, idempotentHint: false },
   schema: z.object({
     body: paymentMethodEnrollSchema,
     customerId: z.string().min(36).max(64).describe("The unique identifier of the customer (MIN 36, MAX 64)."),
@@ -58,7 +58,7 @@ export const paymentMethodEnrollTool = {
 export const paymentMethodRetrieveTool = {
   method: "paymentMethodRetrieve",
   description: `Retrieve an enrolled payment method by customer and payment method ID.`,
-  annotations: { openWorldHint: true, title: "Retrieve Payment Method", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Payment Method", readOnlyHint: true, destructiveHint: false },
   schema: z.object({
     customer_id: z.string().min(36).max(64).describe("The unique identifier of the customer (MIN 36, MAX 64)."),
     payment_method_id: z.string().min(36).max(64).describe("The unique identifier of the payment method (MIN 36, MAX 64)."),
@@ -90,7 +90,7 @@ export const paymentMethodRetrieveTool = {
 export const paymentMethodRetrieveEnrolledTool = {
   method: "paymentMethodRetrieveEnrolled",
   description: `Retrieve all enrolled payment methods for a customer.`,
-  annotations: { openWorldHint: true, title: "Retrieve Enrolled Payment Methods", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Enrolled Payment Methods", readOnlyHint: true, destructiveHint: false },
   schema: z.object({
     customer_id: z.string().min(36).max(64).describe("The unique identifier of the customer (MIN 36, MAX 64)."),
   }),
@@ -121,7 +121,7 @@ export const paymentMethodRetrieveEnrolledTool = {
 export const paymentMethodUnenrollTool = {
   method: "paymentMethodUnenroll",
   description: `Unenroll a saved payment method for the user.`,
-  annotations: { openWorldHint: true, title: "Unenroll Payment Method", destructiveHint: true, idempotentHint: true },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Unenroll Payment Method", destructiveHint: true, idempotentHint: true },
   schema: z.object({
     customer_id: z.string().min(36).max(64).describe("The unique identifier of the customer (MIN 36, MAX 64)."),
     payment_method_id: z.string().min(36).max(64).describe("The unique identifier of the payment method (MIN 36, MAX 64)."),

--- a/src/tools/payments/index.ts
+++ b/src/tools/payments/index.ts
@@ -21,7 +21,7 @@ import type {
 export const paymentCreateTool = {
   method: "paymentCreate",
   description: "Create a new payment in Yuno.",
-  annotations: { openWorldHint: true, title: "Create Payment", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Create Payment", destructiveHint: false, idempotentHint: false },
   schema: paymentCreateSchema,
   outputSchema: yunoPaymentOutputSchema,
   handler:
@@ -67,7 +67,7 @@ export const paymentCreateTool = {
 export const paymentRetrieveTool = {
   method: "paymentRetrieve",
   description: "Retrieve a payment by ID in Yuno.",
-  annotations: { openWorldHint: true, title: "Retrieve Payment", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Payment", readOnlyHint: true, destructiveHint: false },
   schema: z.object({
     payment_id: z.string().describe("The unique identifier of the payment"),
   }),
@@ -110,7 +110,7 @@ export const paymentRetrieveTool = {
 export const paymentRetrieveByMerchantOrderIdTool = {
   method: "paymentRetrieveByMerchantOrderId",
   description: "Retrieve payments by merchant order ID in Yuno.",
-  annotations: { openWorldHint: true, title: "Retrieve Payment by Merchant Order ID", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Payment by Merchant Order ID", readOnlyHint: true, destructiveHint: false },
   schema: z.object({
     merchant_order_id: z.string().describe("The unique identifier of the order for the payment (merchant_order_id)"),
   }),
@@ -153,7 +153,7 @@ export const paymentRetrieveByMerchantOrderIdTool = {
 export const paymentRefundTool = {
   method: "paymentRefund",
   description: "Refund a payment in Yuno.",
-  annotations: { openWorldHint: true, title: "Refund Payment", destructiveHint: true, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Refund Payment", destructiveHint: true, idempotentHint: false },
   schema: z.object({
     paymentId: z.string().min(36).max(64).describe("The unique identifier of the payment (MIN 36, MAX 64 characters)"),
     transactionId: z.string().min(36).max(64).describe("The unique identifier of the transaction (MIN 36, MAX 64 characters)"),
@@ -210,7 +210,7 @@ export const paymentRefundTool = {
 export const paymentCancelOrRefundTool = {
   method: "paymentCancelOrRefund",
   description: "Cancel or refund a payment in Yuno.",
-  annotations: { openWorldHint: true, title: "Cancel or Refund Payment", destructiveHint: true, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Cancel or Refund Payment", destructiveHint: true, idempotentHint: false },
   schema: z.object({
     paymentId: z.string().min(36).max(64).describe("The unique identifier of the payment (MIN 36, MAX 64 characters)"),
     body: paymentRefundSchema,
@@ -264,7 +264,7 @@ export const paymentCancelOrRefundTool = {
 export const paymentCancelOrRefundWithTransactionTool = {
   method: "paymentCancelOrRefundWithTransaction",
   description: "Cancel or refund a payment with transaction in Yuno.",
-  annotations: { openWorldHint: true, title: "Cancel or Refund Payment with Transaction", destructiveHint: true, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Cancel or Refund Payment with Transaction", destructiveHint: true, idempotentHint: false },
   schema: z.object({
     paymentId: z.string().min(36).max(64).describe("The unique identifier of the payment (MIN 36, MAX 64 characters)"),
     transactionId: z.string().min(36).max(64).describe("The unique identifier of the transaction (MIN 36, MAX 64 characters)"),
@@ -321,7 +321,7 @@ export const paymentCancelOrRefundWithTransactionTool = {
 export const paymentCancelTool = {
   method: "paymentCancel",
   description: "Cancel a payment in Yuno.",
-  annotations: { openWorldHint: true, title: "Cancel Payment", destructiveHint: true, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Cancel Payment", destructiveHint: true, idempotentHint: false },
   schema: z.object({
     paymentId: z.string().min(36).max(64).describe("The unique identifier of the payment (MIN 36, MAX 64 characters)"),
     transactionId: z.string().min(36).max(64).describe("The unique identifier of the transaction (MIN 36, MAX 64 characters)"),
@@ -378,7 +378,7 @@ export const paymentCancelTool = {
 export const paymentAuthorizeTool = {
   method: "paymentAuthorize",
   description: "Authorize a payment in Yuno.",
-  annotations: { openWorldHint: true, title: "Authorize Payment", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Authorize Payment", destructiveHint: false, idempotentHint: false },
   schema: paymentCreateSchema,
   outputSchema: yunoPaymentOutputSchema,
   handler:
@@ -430,7 +430,7 @@ export const paymentAuthorizeTool = {
 export const paymentCaptureAuthorizationTool = {
   method: "paymentCaptureAuthorization",
   description: "Capture an authorized payment in Yuno.",
-  annotations: { openWorldHint: true, title: "Capture Payment Authorization", destructiveHint: true, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Capture Payment Authorization", destructiveHint: true, idempotentHint: false },
   schema: z.object({
     paymentId: z.string().min(36).max(64).describe("The unique identifier of the payment (MIN 36, MAX 64 characters)"),
     transactionId: z.string().min(36).max(64).describe("The unique identifier of the transaction (MIN 36, MAX 64 characters)"),

--- a/src/tools/recipients/index.ts
+++ b/src/tools/recipients/index.ts
@@ -7,7 +7,7 @@ import type { RecipientCreateSchema, RecipientUpdateSchema, YunoRecipient } from
 export const recipientCreateTool = {
   method: "recipientCreate",
   description: "Create a recipient in Yuno.",
-  annotations: { openWorldHint: true, title: "Create Recipient", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Create Recipient", destructiveHint: false, idempotentHint: false },
   schema: recipientCreateSchema,
   outputSchema: yunoRecipientOutputSchema,
   handler:
@@ -40,7 +40,7 @@ export const recipientCreateTool = {
 export const recipientRetrieveTool = {
   method: "recipientRetrieve",
   description: "Retrieve a recipient in Yuno by its ID.",
-  annotations: { openWorldHint: true, title: "Retrieve Recipient", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Recipient", readOnlyHint: true, destructiveHint: false },
   schema: z.object({
     recipientId: z.string().describe("The unique identifier of the recipient to retrieve"),
   }),
@@ -71,7 +71,7 @@ export const recipientRetrieveTool = {
 export const recipientUpdateTool = {
   method: "recipientUpdate",
   description: "Update a recipient in Yuno by its ID.",
-  annotations: { openWorldHint: true, title: "Update Recipient", destructiveHint: false, idempotentHint: true },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Update Recipient", destructiveHint: false, idempotentHint: true },
   schema: recipientUpdateSchema,
   outputSchema: yunoRecipientOutputSchema,
   handler:
@@ -100,7 +100,7 @@ export const recipientUpdateTool = {
 export const recipientDeleteTool = {
   method: "recipientDelete",
   description: "Delete a recipient in Yuno by its ID.",
-  annotations: { openWorldHint: true, title: "Delete Recipient", destructiveHint: true, idempotentHint: true },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Delete Recipient", destructiveHint: true, idempotentHint: true },
   schema: z.object({
     recipientId: z.string().describe("The unique identifier of the recipient to delete"),
   }),

--- a/src/tools/routing/index.ts
+++ b/src/tools/routing/index.ts
@@ -19,7 +19,7 @@ import { z } from "zod";
 export const routingLoginTool = {
     method: "routingLogin",
     description: "Authenticate to the Yuno dashboard. You must provide your username (email) and your secret credential. The remember_device option is automatically set to false for security.",
-    annotations: { openWorldHint: true, title: "Login to Yuno Dashboard", destructiveHint: false, idempotentHint: true },
+    annotations: { openWorldHint: true, readOnlyHint: false, title: "Login to Yuno Dashboard", destructiveHint: false, idempotentHint: true },
     schema: routingLoginSchema,
     outputSchema: yunoRoutingLoginOutputSchema,
     handler:
@@ -48,7 +48,7 @@ export const routingLoginTool = {
 export const routingCreateTool = {
     method: "routingCreate",
     description: "Create a routing configuration. You must provide the name and payment method.",
-    annotations: { openWorldHint: true, title: "Create Routing Configuration", destructiveHint: false, idempotentHint: false },
+    annotations: { openWorldHint: true, readOnlyHint: false, title: "Create Routing Configuration", destructiveHint: false, idempotentHint: false },
     schema: routingCreateSchema,
     outputSchema: yunoRoutingWorkflowOutputSchema,
     handler:
@@ -77,7 +77,7 @@ export const routingCreateTool = {
 export const routingGetProvidersTool = {
     method: "routingGetProviders",
     description: "Retrieve all routing connections for a specific payment method. The account_code is automatically taken from the client configuration.",
-    annotations: { openWorldHint: true, title: "Retrieve Routing Providers", readOnlyHint: true },
+    annotations: { openWorldHint: true, title: "Retrieve Routing Providers", readOnlyHint: true, destructiveHint: false },
     schema: routingGetConnectionsSchema,
     outputSchema: yunoRoutingIntegrationsOutputSchema,
     handler:
@@ -105,7 +105,7 @@ export const routingGetProvidersTool = {
 export const routingRetrieveTool = {
     method: "routingRetrieve",
     description: "Retrieve a routing workflow configuration by version code.",
-    annotations: { openWorldHint: true, title: "Retrieve Routing Workflow", readOnlyHint: true },
+    annotations: { openWorldHint: true, title: "Retrieve Routing Workflow", readOnlyHint: true, destructiveHint: false },
     schema: z.object({
         versionCode: z.string().min(1).describe("The version code to retrieve"),
     }),
@@ -135,7 +135,7 @@ export const routingRetrieveTool = {
 export const routingUpdateTool = {
     method: "routingUpdate",
     description: "Configure a routing provider by setting up the provider connection in an existing workflow.",
-    annotations: { openWorldHint: true, title: "Update Routing Workflow", destructiveHint: false, idempotentHint: true },
+    annotations: { openWorldHint: true, readOnlyHint: false, title: "Update Routing Workflow", destructiveHint: false, idempotentHint: true },
     schema: workflowRequestSchema,
     outputSchema: yunoRoutingWorkflowOutputSchema,
     handler:
@@ -163,7 +163,7 @@ export const routingUpdateTool = {
 export const routingPostTool = {
     method: "routingPost",
     description: "Publish a routing workflow configuration to make it active in the Yuno API.",
-    annotations: { openWorldHint: true, title: "Publish Routing Workflow", destructiveHint: true, idempotentHint: true },
+    annotations: { openWorldHint: true, readOnlyHint: false, title: "Publish Routing Workflow", destructiveHint: true, idempotentHint: true },
     schema: z.object({
         versionCode: z.string().min(1).describe("The version code to post"),
     }),
@@ -193,7 +193,7 @@ export const routingPostTool = {
 export const routingLogOutTool = {
     method: "routingLogOut",
     description: "Log out from the Yuno dashboard. This will invalidate the current session.",
-    annotations: { openWorldHint: true, title: "Logout from Yuno Dashboard", destructiveHint: true, idempotentHint: true },
+    annotations: { openWorldHint: true, readOnlyHint: false, title: "Logout from Yuno Dashboard", destructiveHint: true, idempotentHint: true },
     schema: z.object({}),
     outputSchema: yunoRoutingLogoutOutputSchema,
     handler:

--- a/src/tools/subscriptions/index.ts
+++ b/src/tools/subscriptions/index.ts
@@ -7,7 +7,7 @@ import type { SubscriptionCreateSchema, SubscriptionUpdateSchema, YunoSubscripti
 export const subscriptionCreateTool = {
   method: "subscriptionCreate",
   description: "Create a subscription in Yuno.",
-  annotations: { openWorldHint: true, title: "Create Subscription", destructiveHint: false, idempotentHint: false },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Create Subscription", destructiveHint: false, idempotentHint: false },
   schema: subscriptionCreateSchema,
   outputSchema: yunoSubscriptionOutputSchema,
   handler:
@@ -40,7 +40,7 @@ export const subscriptionCreateTool = {
 export const subscriptionRetrieveTool = {
   method: "subscriptionRetrieve",
   description: "Retrieve a subscription in Yuno by its ID.",
-  annotations: { openWorldHint: true, title: "Retrieve Subscription", readOnlyHint: true },
+  annotations: { openWorldHint: true, title: "Retrieve Subscription", readOnlyHint: true, destructiveHint: false },
   schema: z.object({
     subscriptionId: z.string().describe("The unique identifier of the subscription to retrieve"),
   }),
@@ -71,7 +71,7 @@ export const subscriptionRetrieveTool = {
 export const subscriptionPauseTool = {
   method: "subscriptionPause",
   description: "Pause a subscription in Yuno by its ID.",
-  annotations: { openWorldHint: true, title: "Pause Subscription", destructiveHint: true, idempotentHint: true },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Pause Subscription", destructiveHint: true, idempotentHint: true },
   schema: z.object({
     subscriptionId: z.string().describe("The unique identifier of the subscription to pause"),
   }),
@@ -102,7 +102,7 @@ export const subscriptionPauseTool = {
 export const subscriptionResumeTool = {
   method: "subscriptionResume",
   description: "Resume a subscription in Yuno by its ID.",
-  annotations: { openWorldHint: true, title: "Resume Subscription", destructiveHint: false, idempotentHint: true },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Resume Subscription", destructiveHint: false, idempotentHint: true },
   schema: z.object({
     subscriptionId: z.string().describe("The unique identifier of the subscription to resume"),
   }),
@@ -133,7 +133,7 @@ export const subscriptionResumeTool = {
 export const subscriptionUpdateTool = {
   method: "subscriptionUpdate",
   description: "Update a subscription in Yuno by its ID.",
-  annotations: { openWorldHint: true, title: "Update Subscription", destructiveHint: false, idempotentHint: true },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Update Subscription", destructiveHint: false, idempotentHint: true },
   schema: subscriptionUpdateSchema,
   outputSchema: yunoSubscriptionOutputSchema,
   handler:
@@ -162,7 +162,7 @@ export const subscriptionUpdateTool = {
 export const subscriptionCancelTool = {
   method: "subscriptionCancel",
   description: "Cancel a subscription in Yuno by its ID.",
-  annotations: { openWorldHint: true, title: "Cancel Subscription", destructiveHint: true, idempotentHint: true },
+  annotations: { openWorldHint: true, readOnlyHint: false, title: "Cancel Subscription", destructiveHint: true, idempotentHint: true },
   schema: z.object({
     subscriptionId: z.string().describe("The unique identifier of the subscription to cancel"),
   }),


### PR DESCRIPTION
## Summary
OpenAI Apps SDK reviewers expect every MCP tool to declare all three behavioural hints (`readOnlyHint`, `destructiveHint`, `openWorldHint`) explicitly, not rely on defaults. Before this PR, read tools had only `readOnlyHint: true` and write tools had only `destructiveHint: …` — both were missing one of the required hints.

After this PR each of the 47 tool annotations carries all three:
- read tools: `readOnlyHint: true, destructiveHint: false, openWorldHint: true`
- write tools: `readOnlyHint: false, destructiveHint: <true|false>, openWorldHint: true`

Bumps to `0.4.2`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` 121/121 pass
- [x] All 47 tools advertise `readOnlyHint`, `destructiveHint`, `openWorldHint` (verified via `grep -rL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metadata-only changes that standardize tool `annotations` (explicit `readOnlyHint`/`destructiveHint`/`openWorldHint`) plus a patch version bump, with no changes to tool handlers or API calls.
> 
> **Overview**
> Bumps package/server version to `0.4.2`.
> 
> Standardizes MCP tool `annotations` across the payment/checkout/customer/subscription/routing/etc. toolset by explicitly setting behavioral hints (notably adding `readOnlyHint: false` on write tools and `destructiveHint: false` on read tools) instead of relying on defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0781eb402b4cfef30750d67689a1d2bb5e77c988. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->